### PR TITLE
Allow to aggregate empty cells

### DIFF
--- a/src/AgFEM/CellAggregation.jl
+++ b/src/AgFEM/CellAggregation.jl
@@ -151,10 +151,7 @@ function _aggregate_by_threshold_barrier(
   for iter in 1:max_iters
     all_aggregated = true
     for cell in 1:n_cells
-      if cell_to_unit_cut_meas[cell] < threshold &&
-         ! cell_to_touched[cell] &&
-         cell_to_inoutcut[cell] ∈ (CUT,loc)
-
+      if ! cell_to_touched[cell] && cell_to_inoutcut[cell] ∈ (CUT,loc)
         neigh_cell = _find_best_neighbor(
           c1,c2,c3,c4,cell,
           cell_to_faces,

--- a/src/AgFEM/CellAggregation.jl
+++ b/src/AgFEM/CellAggregation.jl
@@ -112,6 +112,8 @@ function _aggregate_by_threshold(threshold,cut,geo,loc,facet_to_inoutcut)
   cell_to_meas = get_cell_measure(bgtrian)
   cell_to_unit_cut_meas = lazy_map(/,cell_to_cut_meas,cell_to_meas)
 
+  cell_to_inoutcut = compute_bgcell_to_inoutcut(cut,geo)
+
   cell_to_coords = get_cell_coordinates(bgtrian)
   topo = get_grid_topology(model)
   D = num_cell_dims(model)
@@ -119,12 +121,12 @@ function _aggregate_by_threshold(threshold,cut,geo,loc,facet_to_inoutcut)
   face_to_cells = get_faces(topo,D-1,D)
 
   _aggregate_by_threshold_barrier(
-    threshold,cell_to_unit_cut_meas,facet_to_inoutcut,
+    threshold,cell_to_unit_cut_meas,facet_to_inoutcut,cell_to_inoutcut,
     loc,cell_to_coords,cell_to_faces,face_to_cells)
 end
 
 function _aggregate_by_threshold_barrier(
-  threshold,cell_to_unit_cut_meas,facet_to_inoutcut,
+  threshold,cell_to_unit_cut_meas,facet_to_inoutcut,cell_to_inoutcut,
   loc,cell_to_coords,cell_to_faces,face_to_cells)
 
   n_cells = length(cell_to_unit_cut_meas)
@@ -149,7 +151,10 @@ function _aggregate_by_threshold_barrier(
   for iter in 1:max_iters
     all_aggregated = true
     for cell in 1:n_cells
-      if 0 < cell_to_unit_cut_meas[cell] < threshold && ! cell_to_touched[cell]
+      if cell_to_unit_cut_meas[cell] < threshold &&
+         ! cell_to_touched[cell] &&
+         cell_to_inoutcut[cell] ∈ (CUT,loc)
+
         neigh_cell = _find_best_neighbor(
           c1,c2,c3,c4,cell,
           cell_to_faces,

--- a/src/AgFEM/CellAggregation.jl
+++ b/src/AgFEM/CellAggregation.jl
@@ -134,7 +134,7 @@ function _aggregate_by_threshold_barrier(
   cell_to_touched = fill(false,n_cells)
 
   for cell in 1:n_cells
-    if cell_to_inoutcut[cell] == loc || cell_to_unit_cut_meas[cell] ≥ threshold
+    if cell_to_unit_cut_meas[cell] ≥ threshold
       cell_to_cellin[cell] = cell
       cell_to_touched[cell] = true
     end

--- a/src/AgFEM/CellAggregation.jl
+++ b/src/AgFEM/CellAggregation.jl
@@ -134,7 +134,7 @@ function _aggregate_by_threshold_barrier(
   cell_to_touched = fill(false,n_cells)
 
   for cell in 1:n_cells
-    if cell_to_unit_cut_meas[cell] ≥ threshold
+    if cell_to_inoutcut[cell] == loc || cell_to_unit_cut_meas[cell] ≥ threshold
       cell_to_cellin[cell] = cell
       cell_to_touched[cell] = true
     end
@@ -151,7 +151,7 @@ function _aggregate_by_threshold_barrier(
   for iter in 1:max_iters
     all_aggregated = true
     for cell in 1:n_cells
-      if ! cell_to_touched[cell] && cell_to_inoutcut[cell] ∈ (CUT,loc)
+      if ! cell_to_touched[cell] && cell_to_inoutcut[cell] == CUT
         neigh_cell = _find_best_neighbor(
           c1,c2,c3,c4,cell,
           cell_to_faces,


### PR DESCRIPTION
@fverdugo 

the criterion to discard `out` cells  in the `_aggregate_by_threshold_barrier() `  is now integer-based. It comes from `cell_to_inoutcut` instead unitary measures (`cell_to_unit_cut_meas`).

It allows to aggregate cells with 0.0 `in` volume.