### PR TITLE
Shape derivative

### DIFF
--- a/src/Interfaces/SubCellTriangulations.jl
+++ b/src/Interfaces/SubCellTriangulations.jl
@@ -1,9 +1,9 @@
 
-struct SubCellData{Dr,Dp,T} <: GridapType
+struct SubCellData{Dr,Dp,Tp,Tr} <: GridapType
   cell_to_points::Table{Int32,Vector{Int32},Vector{Int32}}
   cell_to_bgcell::Vector{Int32}
-  point_to_coords::Vector{Point{Dp,T}}
-  point_to_rcoords::Vector{Point{Dr,T}}
+  point_to_coords::Vector{Point{Dp,Tp}}
+  point_to_rcoords::Vector{Point{Dr,Tr}}
 end
 
 function SubCellData(st::SubCellData,newcells::AbstractVector{<:Integer})

--- a/src/Interfaces/SubFacetTriangulations.jl
+++ b/src/Interfaces/SubFacetTriangulations.jl
@@ -1,7 +1,7 @@
 
-struct SubFacetData{Dp,T} <: GridapType
+struct SubFacetData{Dp,T,Tn} <: GridapType
   facet_to_points::Table{Int32,Vector{Int32},Vector{Int32}}
-  facet_to_normal::Vector{Point{Dp,T}}
+  facet_to_normal::Vector{Point{Dp,Tn}}
   facet_to_bgcell::Vector{Int32}
   point_to_coords::Vector{Point{Dp,T}}
   point_to_rcoords::Vector{Point{Dp,T}}
@@ -22,20 +22,20 @@ end
 
 # Implementation of the Gridap.Triangulation interface
 
-struct SubFacetTriangulation{Dc,Dp,T} <: Grid{Dc,Dp}
-  subfacets::SubFacetData{Dp,T}
+struct SubFacetTriangulation{Dc,Dp,T,Tn} <: Grid{Dc,Dp}
+  subfacets::SubFacetData{Dp,T,Tn}
   bgtrian::Triangulation
   facet_types::Vector{Int8}
   reffes::Vector{LagrangianRefFE{Dc}}
   facet_ref_map
 
-  function SubFacetTriangulation(st::SubFacetData{Dp,T},bgtrian::Triangulation) where {Dp,T}
+  function SubFacetTriangulation(st::SubFacetData{Dp,T,Tn},bgtrian::Triangulation) where {Dp,T,Tn}
     Dc = Dp - 1
     reffe = LagrangianRefFE(Float64,Simplex(Val{Dc}()),1)
     facet_types = fill(Int8(1),length(st.facet_to_points))
     reffes = [reffe]
     face_ref_map = _setup_facet_ref_map(st,reffe,facet_types)
-    new{Dc,Dp,T}(st,bgtrian,facet_types,reffes,face_ref_map)
+    new{Dc,Dp,T,Tn}(st,bgtrian,facet_types,reffes,face_ref_map)
   end
 end
 
@@ -113,10 +113,10 @@ function merge_sub_face_data(ls_to_subfacets,ls_to_ls_to_facet_to_inout)
   fst, ls_to_facet_to_inout
 end
 
-function Base.empty(st::SubFacetData{Dp,T}) where {Dp,T}
+function Base.empty(st::SubFacetData{Dp,T,Tn}) where {Dp,T,Tn}
 
   facet_to_points = Table(Int32[],Int32[1,])
-  facet_to_normal = Point{Dp,T}[]
+  facet_to_normal = Point{Dp,Tn}[]
   facet_to_bgcell = Int32[]
   point_to_coords = Point{Dp,T}[]
   point_to_rcoords = Point{Dp,T}[]

--- a/src/LevelSetCutters/CutTriangulations.jl
+++ b/src/LevelSetCutters/CutTriangulations.jl
@@ -22,7 +22,7 @@ end
 function CutTriangulation(
   sub_trian,
   done_ls_to_cell_to_inoutcut::Vector{Vector{Int8}},
-  pending_ls_to_point_to_value)
+  pending_ls_to_point_to_value::Vector{Vector{T}}) where T
 
   Dc = get_cell_dim(sub_trian)
   p = Simplex(Val{Dc}())

--- a/src/LevelSetCutters/CutTriangulations.jl
+++ b/src/LevelSetCutters/CutTriangulations.jl
@@ -576,12 +576,10 @@ function _simplexify(
   ntcells = ncells*nltcells
   ntpoints = ncells*nlpoints
   T = eltype(first(ls_to_point_to_value))
-  
   tcell_to_tpoints_data = zeros(eltype(cell_to_points.data),nsp*ntcells)
   tcell_to_tpoints_ptrs = fill(eltype(cell_to_points.ptrs)(nsp),ntcells+1)
   length_to_ptrs!(tcell_to_tpoints_ptrs)
   tcell_to_tpoints = Table(tcell_to_tpoints_data,tcell_to_tpoints_ptrs)
-  
   Dp = eltype(point_to_coords).parameters[1]
   tpoint_to_coords = zeros(Point{Dp,T},ntpoints)
   tpoint_to_rcoords = zeros(Point{Dc,T},ntpoints)

--- a/src/LevelSetCutters/CutTriangulations.jl
+++ b/src/LevelSetCutters/CutTriangulations.jl
@@ -11,10 +11,10 @@ function MiniCell(p::Polytope{0})
   MiniCell(1,[Int[]])
 end
 
-struct CutTriangulation{Dc,A}
+struct CutTriangulation{Dc,A,T}
   sub_trian::A
   done_ls_to_cell_to_inoutcut::Vector{Vector{Int8}}
-  pending_ls_to_point_to_value::Vector{Vector{Float64}}
+  pending_ls_to_point_to_value::Vector{Vector{T}}
   minicell::MiniCell
   table::LookupTable{Dc}
 end
@@ -22,7 +22,7 @@ end
 function CutTriangulation(
   sub_trian,
   done_ls_to_cell_to_inoutcut::Vector{Vector{Int8}},
-  pending_ls_to_point_to_value::Vector{Vector{Float64}})
+  pending_ls_to_point_to_value)
 
   Dc = get_cell_dim(sub_trian)
   p = Simplex(Val{Dc}())
@@ -56,7 +56,7 @@ function allocate_sub_triangulation(
   done_ls_to_cell_to_inoutcut = [ zeros(Int8,n_cells) for ls in 1:n_done_ls]
 
   n_pending_ls = length(m.pending_ls_to_point_to_value)
-  pending_ls_to_point_to_value = [zeros(Float64,n_points) for ls in 1:n_pending_ls]
+  pending_ls_to_point_to_value = [zeros(eltype(eltype(m.pending_ls_to_point_to_value)),n_points) for ls in 1:n_pending_ls]
 
   s = CutTriangulation(
     sub_trian,done_ls_to_cell_to_inoutcut,pending_ls_to_point_to_value)
@@ -575,13 +575,15 @@ function _simplexify(
   nltcells = length(ltcell_to_lpoints)
   ntcells = ncells*nltcells
   ntpoints = ncells*nlpoints
-  T = eltype(eltype(point_to_coords))
-
+  T = eltype(first(ls_to_point_to_value))
+  
   tcell_to_tpoints_data = zeros(eltype(cell_to_points.data),nsp*ntcells)
   tcell_to_tpoints_ptrs = fill(eltype(cell_to_points.ptrs)(nsp),ntcells+1)
   length_to_ptrs!(tcell_to_tpoints_ptrs)
   tcell_to_tpoints = Table(tcell_to_tpoints_data,tcell_to_tpoints_ptrs)
-  tpoint_to_coords = zeros(eltype(point_to_coords),ntpoints)
+  
+  Dp = eltype(point_to_coords).parameters[1]
+  tpoint_to_coords = zeros(Point{Dp,T},ntpoints)
   tpoint_to_rcoords = zeros(Point{Dc,T},ntpoints)
   T = eltype(first(ls_to_point_to_value))
   ls_to_tpoint_to_value = [ zeros(T,ntpoints) for i in 1:length(ls_to_point_to_value)]

--- a/test/InterfacesTests/ShapeDerivativeTests.jl
+++ b/test/InterfacesTests/ShapeDerivativeTests.jl
@@ -1,0 +1,52 @@
+module ShapeDerivativeTests
+
+using ForwardDiff
+using GridapEmbedded
+using GridapEmbedded.LevelSetCutters
+using Gridap
+using Gridap.ReferenceFEs
+using Gridap.Arrays
+
+L=1
+n = 5
+dimensions = 2; domain = (0,L,0,L); cells=(n,n)
+bgmodel = CartesianDiscreteModel(domain,cells)
+point_to_coords = collect1d(get_node_coordinates(bgmodel))
+
+geoc = disk(L/4,x0=Point(L/2,L/2)) 
+geoc = discretize(geoc,bgmodel)
+ϕ = geoc.tree.data[1] # signed distance function
+
+geo = DiscreteGeometry(ϕ,point_to_coords,name="")
+cutgeo = cut(bgmodel,geo)
+
+Ω = Triangulation(cutgeo)
+
+order = 1
+model = DiscreteModel(cutgeo)
+V = TestFESpace(model,ReferenceFE(lagrangian,Float64,order),conformity=:H1)
+u(x) = x[1]^2 - x[2]
+uₕ = interpolate(u,V) 
+
+function f(ϕ)
+  ϕ = collect1d(ϕ)
+  geo = DiscreteGeometry(ϕ,point_to_coords,name="")
+  cutgeo = cut(bgmodel,geo)
+  Ω = Triangulation(cutgeo)
+  degree = 2*order
+  dΩ = Measure(Ω,degree)
+  dc = (∫(uₕ)dΩ)
+  sum(map(sum,values(dc.dict)))
+end
+
+df(ϕ) = ForwardDiff.gradient(f,ϕ) # gradient of an integral wrt the signed distance function
+
+df(ϕ)
+
+#using FiniteDifferences
+#using Test
+#dfFD(ϕ) = grad(central_fdm(2, 1), f, ϕ)[1]
+#tol=1e-8
+#@test sum((df(ϕ)) - (dfFD(ϕ))) < tol
+
+end 

--- a/test/InterfacesTests/ShapeDerivativeTests.jl
+++ b/test/InterfacesTests/ShapeDerivativeTests.jl
@@ -35,18 +35,17 @@ function f(ϕ)
   Ω = Triangulation(cutgeo)
   degree = 2*order
   dΩ = Measure(Ω,degree)
-  dc = (∫(uₕ)dΩ)
-  sum(map(sum,values(dc.dict)))
+  sum(∫(uₕ)dΩ)
 end
 
 df(ϕ) = ForwardDiff.gradient(f,ϕ) # gradient of an integral wrt the signed distance function
 
 df(ϕ)
 
-#using FiniteDifferences
-#using Test
-#dfFD(ϕ) = grad(central_fdm(2, 1), f, ϕ)[1]
-#tol=1e-8
-#@test sum((df(ϕ)) - (dfFD(ϕ))) < tol
+using FiniteDifferences
+using Test
+dfFD(ϕ) = grad(central_fdm(2, 1), f, ϕ)[1]
+tol=1e-8
+@test sum((df(ϕ)) - (dfFD(ϕ))) < tol
 
 end 


### PR DESCRIPTION
Modifications to allow propogation of duals for autodiff ( to resolve gridap/GridapEmbedded.jl#51 ).

In this commit, type parameters are introduced to allow for dual numbers in the description of the geometry. A test is added for the target functionality but not included in the test set for the sake of not adding ForwardDiff as a dependency. 