### PR TITLE
adding TraceFEMTests.jl

### DIFF
--- a/src/Interfaces/EmbeddedDiscretizations.jl
+++ b/src/Interfaces/EmbeddedDiscretizations.jl
@@ -373,7 +373,7 @@ end
 
 function GhostSkeleton(cut::EmbeddedDiscretization,geo::CSG.Geometry,in_or_out)
 
-  @assert in_or_out in (IN,OUT)
+  @assert in_or_out in (IN,OUT,CUT)
   cell_to_inoutcut = compute_bgcell_to_inoutcut(cut,geo)
   model = cut.bgmodel
   topo = get_grid_topology(model)

--- a/test/GridapEmbeddedTests/TraceFEMTests.jl
+++ b/test/GridapEmbeddedTests/TraceFEMTests.jl
@@ -1,0 +1,64 @@
+module TraceFEMTests
+
+using Gridap
+using GridapEmbedded
+using GridapEmbedded.Interfaces
+using Test
+
+# Select geometry
+const R = 0.7
+geom = disk(R)
+n = 10
+partition = (n,n)
+ud(x) = x[1] - x[2] 
+f(x) = ud(x)
+
+# Setup background model
+box = get_metadata(geom)
+dp = box.pmax - box.pmin
+const h = dp[1]/n
+bgmodel = simplexify(CartesianDiscreteModel(box.pmin,box.pmax,partition))
+Ω_bg = Triangulation(bgmodel)
+
+# Cut Geometry
+cutgeom = cut(bgmodel,geom)
+model_cut = DiscreteModel(cutgeom,geom,(CUT))
+order=1
+V = TestFESpace(model_cut,ReferenceFE(lagrangian,Float64,order),conformity=:H1)
+U = TrialFESpace(V)
+Ωc = Triangulation(cutgeom,geom,(CUT))
+Γ = EmbeddedBoundary(cutgeom)
+Γg = GhostSkeleton(cutgeom,geom,(CUT))
+
+#writevtk(Ωc,"Ωc")
+#writevtk(Γ,"Γ")
+#writevtk(Γg,"Γg")
+
+n_Γ = get_normal_vector(Γ)
+n_Γg = get_normal_vector(Γg)
+
+dΩc = Measure(Ωc,2)
+dΓ = Measure(Γ,2)
+dΓg = Measure(Γg,2)
+
+γd = 10
+γg = 0.1
+
+a(u,v)= ∫( (γd/h)*v*u   ) * dΓ +
+        ∫( (γg*h)*jump(n_Γg⋅∇(v))*jump(n_Γg⋅∇(u))) * dΓg
+
+b(v) =  ∫( (γd/h)*v*ud  ) * dΓ 
+
+op = AffineFEOperator(a,b,U,V)
+
+uh = solve(op)
+
+e = uh-ud
+l2(v) = √(∑(∫(v*v)dΓ))
+
+tol = 1.0e-10
+@test l2(e) < tol
+
+#writevtk(Γ,"u_Γ",cellfields=["uh"=>uh])
+
+end 

--- a/test/GridapEmbeddedTests/runtests.jl
+++ b/test/GridapEmbeddedTests/runtests.jl
@@ -14,4 +14,6 @@ using Test
 
 @time @testset "StokesAgFEM" begin include("StokesAgFEMTests.jl") end
 
+@time @testset "TraceFEM" begin include("TraceFEMTests.jl") end
+
 end


### PR DESCRIPTION
This PR relates relates to solving an equation ( in this case with no derivatives ) on a surface embedded in a volume. TraceFEM is used here for which the space used is the the space of traces of functions in the bulk FESpace on the boundary. Using this method, we can simply used the bulk FESpace restricted to cut cells, integrate along the ```EmbeddedBoundary``` and add some term for stability. This seems to work here, but in the new working branch the possibility to restrict a ```DiscreteModel``` is gone. The warning says to use a restricted Triangulation - but we cannot define a space based on a Triangulation. What is the alternative here if we want a space which only exists on a surface ? 