### PR TITLE
Add unfitted modal c0 machinery

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,661 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.7.2"
+manifest_format = "2.0"
+
+[[deps.AbstractFFTs]]
+deps = ["ChainRulesCore", "LinearAlgebra"]
+git-tree-sha1 = "6f1d9bc1c08f9f4a8fa92e3ea3cb50153a1b40d4"
+uuid = "621f4979-c628-5d54-868e-fcf4e3e8185c"
+version = "1.1.0"
+
+[[deps.AbstractTrees]]
+git-tree-sha1 = "03e0550477d86222521d254b741d470ba17ea0b5"
+uuid = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
+version = "0.3.4"
+
+[[deps.ArgCheck]]
+git-tree-sha1 = "a3a402a35a2f7e0b87828ccabbd5ebfbebe356b4"
+uuid = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+version = "2.3.0"
+
+[[deps.ArgTools]]
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+
+[[deps.ArnoldiMethod]]
+deps = ["LinearAlgebra", "Random", "StaticArrays"]
+git-tree-sha1 = "f87e559f87a45bece9c9ed97458d3afe98b1ebb9"
+uuid = "ec485272-7323-5ecc-a04f-4719b315124d"
+version = "0.1.0"
+
+[[deps.ArrayInterface]]
+deps = ["Compat", "IfElse", "LinearAlgebra", "Requires", "SparseArrays", "Static"]
+git-tree-sha1 = "d0d82f1c0b651173a4f839d84f662d03f3417740"
+uuid = "4fba245c-0d91-5ea0-9b3e-6abc04ee57a9"
+version = "4.0.0"
+
+[[deps.ArrayLayouts]]
+deps = ["FillArrays", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "623a32b87ef0b85d26320a8cc7e57ded707aef64"
+uuid = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"
+version = "0.7.5"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+
+[[deps.BSON]]
+git-tree-sha1 = "ebcd6e22d69f21249b7b8668351ebf42d6dc87a1"
+uuid = "fbb218c0-5317-5bc6-957e-2ee96dd4b1f0"
+version = "0.3.4"
+
+[[deps.Base64]]
+uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
+
+[[deps.BinDeps]]
+deps = ["Libdl", "Pkg", "SHA", "URIParser", "Unicode"]
+git-tree-sha1 = "1289b57e8cf019aede076edab0587eb9644175bd"
+uuid = "9e28174c-4ba2-5203-b857-d8d62c4213ee"
+version = "1.0.2"
+
+[[deps.BlockArrays]]
+deps = ["ArrayLayouts", "FillArrays", "LinearAlgebra"]
+git-tree-sha1 = "5524e27323cf4c4505699c3fb008c3f772269945"
+uuid = "8e7c35d0-a365-5155-bbbb-fb81a777f24e"
+version = "0.16.9"
+
+[[deps.CMake]]
+deps = ["BinDeps"]
+git-tree-sha1 = "50a8b41d2c562fccd9ab841085fc7d1e2706da82"
+uuid = "631607c0-34d2-5d66-819e-eb0f9aa2061a"
+version = "1.2.0"
+
+[[deps.ChainRulesCore]]
+deps = ["Compat", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "926870acb6cbcf029396f2f2de030282b6bc1941"
+uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+version = "1.11.4"
+
+[[deps.ChangesOfVariables]]
+deps = ["ChainRulesCore", "LinearAlgebra", "Test"]
+git-tree-sha1 = "bf98fa45a0a4cee295de98d4c1462be26345b9a1"
+uuid = "9e997f8a-9a97-42d5-a9f1-ce6bfc15e2c0"
+version = "0.1.2"
+
+[[deps.CodecZlib]]
+deps = ["TranscodingStreams", "Zlib_jll"]
+git-tree-sha1 = "ded953804d019afa9a3f98981d99b33e3db7b6da"
+uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
+version = "0.7.0"
+
+[[deps.Combinatorics]]
+git-tree-sha1 = "08c8b6831dc00bfea825826be0bc8336fc369860"
+uuid = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
+version = "1.0.2"
+
+[[deps.CommonSubexpressions]]
+deps = ["MacroTools", "Test"]
+git-tree-sha1 = "7b8a93dba8af7e3b42fecabf646260105ac373f7"
+uuid = "bbf7d656-a473-5ed7-a52c-81e309532950"
+version = "0.3.0"
+
+[[deps.Compat]]
+deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
+git-tree-sha1 = "44c37b4636bc54afac5c574d2d02b625349d6582"
+uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
+version = "3.41.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+
+[[deps.DSP]]
+deps = ["Compat", "FFTW", "IterTools", "LinearAlgebra", "Polynomials", "Random", "Reexport", "SpecialFunctions", "Statistics"]
+git-tree-sha1 = "3e03979d16275ed5d9078d50327332c546e24e68"
+uuid = "717857b8-e6f2-59f4-9121-6e50c889abd2"
+version = "0.7.5"
+
+[[deps.DataAPI]]
+git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
+uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
+version = "1.9.0"
+
+[[deps.DataStructures]]
+deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
+git-tree-sha1 = "3daef5523dd2e769dad2365274f760ff5f282c7d"
+uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
+version = "0.18.11"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+
+[[deps.DelimitedFiles]]
+deps = ["Mmap"]
+uuid = "8bb1440f-4735-579b-a4ab-409b98df4dab"
+
+[[deps.DiffResults]]
+deps = ["StaticArrays"]
+git-tree-sha1 = "c18e98cba888c6c25d1c3b048e4b3380ca956805"
+uuid = "163ba53b-c6d8-5494-b064-1a9d43ac40c5"
+version = "1.0.3"
+
+[[deps.DiffRules]]
+deps = ["LogExpFunctions", "NaNMath", "Random", "SpecialFunctions"]
+git-tree-sha1 = "9bc5dac3c8b6706b58ad5ce24cffd9861f07c94f"
+uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
+version = "1.9.0"
+
+[[deps.Distances]]
+deps = ["LinearAlgebra", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "3258d0659f812acde79e8a74b11f17ac06d0ca04"
+uuid = "b4f34e82-e78d-54a5-968a-f98e89d6e8f7"
+version = "0.10.7"
+
+[[deps.Distributed]]
+deps = ["Random", "Serialization", "Sockets"]
+uuid = "8ba89e20-285c-5b6f-9357-94700520ee1b"
+
+[[deps.DocStringExtensions]]
+deps = ["LibGit2"]
+git-tree-sha1 = "b19534d1895d702889b219c382a6e18010797f0b"
+uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
+version = "0.8.6"
+
+[[deps.Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+
+[[deps.FFTW]]
+deps = ["AbstractFFTs", "FFTW_jll", "LinearAlgebra", "MKL_jll", "Preferences", "Reexport"]
+git-tree-sha1 = "505876577b5481e50d089c1c68899dfb6faebc62"
+uuid = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+version = "1.4.6"
+
+[[deps.FFTW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "c6033cc3892d0ef5bb9cd29b7f2f0331ea5184ea"
+uuid = "f5851436-0d7a-5f13-b9de-f02708fd171a"
+version = "3.3.10+0"
+
+[[deps.FastGaussQuadrature]]
+deps = ["LinearAlgebra", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "58d83dd5a78a36205bdfddb82b1bb67682e64487"
+uuid = "442a2c76-b920-505d-bb47-c5924d526838"
+version = "0.4.9"
+
+[[deps.FastTransforms]]
+deps = ["AbstractFFTs", "ArrayLayouts", "DSP", "FFTW", "FastGaussQuadrature", "FastTransforms_jll", "FillArrays", "Libdl", "LinearAlgebra", "Reexport", "SpecialFunctions", "Test", "ToeplitzMatrices"]
+git-tree-sha1 = "005bf3f2a4c84dc21b6827a0d3567f892774238c"
+uuid = "057dd010-8810-581a-b7be-e3fc3b93f78c"
+version = "0.13.9"
+
+[[deps.FastTransforms_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "FFTW_jll", "JLLWrappers", "LLVMOpenMP_jll", "Libdl", "MPFR_jll", "OpenBLAS_jll", "Pkg"]
+git-tree-sha1 = "21dc8ae16745cafc5708b8615e57443f0bed62fd"
+uuid = "34b6f7d7-08f9-5794-9e10-3819e4c7e49a"
+version = "0.5.4+1"
+
+[[deps.FileIO]]
+deps = ["Pkg", "Requires", "UUIDs"]
+git-tree-sha1 = "67551df041955cc6ee2ed098718c8fcd7fc7aebe"
+uuid = "5789e2e9-d7fb-5bc7-8068-2c6fae9b9549"
+version = "1.12.0"
+
+[[deps.FillArrays]]
+deps = ["LinearAlgebra", "Random", "SparseArrays"]
+git-tree-sha1 = "693210145367e7685d8604aee33d9bfb85db8b31"
+uuid = "1a297f60-69ca-5386-bcde-b61e274b549b"
+version = "0.11.9"
+
+[[deps.FiniteDiff]]
+deps = ["ArrayInterface", "LinearAlgebra", "Requires", "SparseArrays", "StaticArrays"]
+git-tree-sha1 = "6eae72e9943d8992d14359c32aed5f892bda1569"
+uuid = "6a86dc24-6348-571c-b903-95158fe2bd41"
+version = "2.10.0"
+
+[[deps.ForwardDiff]]
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "LogExpFunctions", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "2b72a5624e289ee18256111657663721d59c143e"
+uuid = "f6369f11-7733-5829-9624-2563aa707210"
+version = "0.10.24"
+
+[[deps.GMP_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
+
+[[deps.Gridap]]
+deps = ["AbstractTrees", "BSON", "BlockArrays", "Combinatorics", "DocStringExtensions", "FastGaussQuadrature", "FileIO", "FillArrays", "ForwardDiff", "JLD2", "JSON", "LineSearches", "LinearAlgebra", "NLsolve", "NearestNeighbors", "PolynomialBases", "QuadGK", "Random", "SparseArrays", "SparseMatricesCSR", "StaticArrays", "Test", "WriteVTK"]
+git-tree-sha1 = "00f700ca3a53c08155a656c9213280484547a35e"
+repo-rev = "add_modalC0_machinery"
+repo-url = "https://github.com/gridap/Gridap.jl.git"
+uuid = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
+version = "0.17.12"
+
+[[deps.IfElse]]
+git-tree-sha1 = "debdd00ffef04665ccbb3e150747a77560e8fad1"
+uuid = "615f187c-cbe4-4ef1-ba3b-2fcf58d6d173"
+version = "0.1.1"
+
+[[deps.Inflate]]
+git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
+uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
+version = "0.1.2"
+
+[[deps.IntelOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "d979e54b71da82f3a65b62553da4fc3d18c9004c"
+uuid = "1d5cc7b8-4909-519e-a0f8-d0f5ad9712d0"
+version = "2018.0.3+2"
+
+[[deps.InteractiveUtils]]
+deps = ["Markdown"]
+uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[deps.InverseFunctions]]
+deps = ["Test"]
+git-tree-sha1 = "a7254c0acd8e62f1ac75ad24d5db43f5f19f3c65"
+uuid = "3587e190-3f89-42d0-90ee-14403ec27112"
+version = "0.1.2"
+
+[[deps.IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[deps.IterTools]]
+git-tree-sha1 = "fa6287a4469f5e048d763df38279ee729fbd44e5"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.4.0"
+
+[[deps.JLD2]]
+deps = ["DataStructures", "FileIO", "MacroTools", "Mmap", "Pkg", "Printf", "Reexport", "TranscodingStreams", "UUIDs"]
+git-tree-sha1 = "09ef0c32a26f80b465d808a1ba1e85775a282c97"
+uuid = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+version = "0.4.17"
+
+[[deps.JLLWrappers]]
+deps = ["Preferences"]
+git-tree-sha1 = "642a199af8b68253517b80bd3bfd17eb4e84df6e"
+uuid = "692b3bcd-3c85-4b1f-b108-f13ce0eb3210"
+version = "1.3.0"
+
+[[deps.JSON]]
+deps = ["Dates", "Mmap", "Parsers", "Unicode"]
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
+uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
+version = "0.21.2"
+
+[[deps.LLVMOpenMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "fb6ff6647ed984fd5c7f8d386e67fae1c6aae560"
+uuid = "1d63c593-3942-5779-bab2-d838dc0a180e"
+version = "13.0.1+0"
+
+[[deps.LazyArtifacts]]
+deps = ["Artifacts", "Pkg"]
+uuid = "4af54fe1-eca0-43a8-85a7-787d91b784e3"
+
+[[deps.LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+
+[[deps.LibCURL_jll]]
+deps = ["Artifacts", "LibSSH2_jll", "Libdl", "MbedTLS_jll", "Zlib_jll", "nghttp2_jll"]
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+
+[[deps.LibGit2]]
+deps = ["Base64", "NetworkOptions", "Printf", "SHA"]
+uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[deps.LibSSH2_jll]]
+deps = ["Artifacts", "Libdl", "MbedTLS_jll"]
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+
+[[deps.Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "42b62845d70a619f063a7da093d995ec8e15e778"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.1+1"
+
+[[deps.LightGraphs]]
+deps = ["ArnoldiMethod", "DataStructures", "Distributed", "Inflate", "LinearAlgebra", "Random", "SharedArrays", "SimpleTraits", "SparseArrays", "Statistics"]
+git-tree-sha1 = "432428df5f360964040ed60418dd5601ecd240b6"
+uuid = "093fc24a-ae57-5d10-9952-331d41423f4d"
+version = "1.3.5"
+
+[[deps.LightXML]]
+deps = ["Libdl", "XML2_jll"]
+git-tree-sha1 = "e129d9391168c677cd4800f5c0abb1ed8cb3794f"
+uuid = "9c8b4983-aa76-5018-a973-4c85ecc9e179"
+version = "0.9.0"
+
+[[deps.LineSearches]]
+deps = ["LinearAlgebra", "NLSolversBase", "NaNMath", "Parameters", "Printf"]
+git-tree-sha1 = "f27132e551e959b3667d8c93eae90973225032dd"
+uuid = "d3d80556-e9d4-5f37-9878-2ab0fcc64255"
+version = "7.1.1"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+
+[[deps.LogExpFunctions]]
+deps = ["ChainRulesCore", "ChangesOfVariables", "DocStringExtensions", "InverseFunctions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "e5718a00af0ab9756305a0392832c8952c7426c1"
+uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
+version = "0.3.6"
+
+[[deps.Logging]]
+uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
+
+[[deps.MKL_jll]]
+deps = ["Artifacts", "IntelOpenMP_jll", "JLLWrappers", "LazyArtifacts", "Libdl", "Pkg"]
+git-tree-sha1 = "e595b205efd49508358f7dc670a940c790204629"
+uuid = "856f044c-d86e-5d09-b602-aeab76dc8ba7"
+version = "2022.0.0+0"
+
+[[deps.MPFR_jll]]
+deps = ["Artifacts", "GMP_jll", "Libdl"]
+uuid = "3a97d323-0669-5f0c-9066-3539efd106a3"
+
+[[deps.MacroTools]]
+deps = ["Markdown", "Random"]
+git-tree-sha1 = "3d3e902b31198a27340d0bf00d6ac452866021cf"
+uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
+version = "0.5.9"
+
+[[deps.Markdown]]
+deps = ["Base64"]
+uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
+
+[[deps.MbedTLS_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
+
+[[deps.MiniQhull]]
+deps = ["CMake", "Libdl", "Qhull_jll"]
+git-tree-sha1 = "e21881c219cc9de70ee990fabfd1f031aa4f414a"
+uuid = "978d7f02-9e05-4691-894f-ae31a51d76ca"
+version = "0.3.0"
+
+[[deps.Missings]]
+deps = ["DataAPI"]
+git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
+uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
+version = "1.0.2"
+
+[[deps.Mmap]]
+uuid = "a63ad114-7e13-5084-954f-fe012c677804"
+
+[[deps.MozillaCACerts_jll]]
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+
+[[deps.MutableArithmetics]]
+deps = ["LinearAlgebra", "SparseArrays", "Test"]
+git-tree-sha1 = "ba8c0f8732a24facba709388c74ba99dcbfdda1e"
+uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
+version = "1.0.0"
+
+[[deps.NLSolversBase]]
+deps = ["DiffResults", "Distributed", "FiniteDiff", "ForwardDiff"]
+git-tree-sha1 = "50310f934e55e5ca3912fb941dec199b49ca9b68"
+uuid = "d41bc354-129a-5804-8e4c-c37616107c6c"
+version = "7.8.2"
+
+[[deps.NLsolve]]
+deps = ["Distances", "LineSearches", "LinearAlgebra", "NLSolversBase", "Printf", "Reexport"]
+git-tree-sha1 = "019f12e9a1a7880459d0173c182e6a99365d7ac1"
+uuid = "2774e3e8-f4cf-5e23-947b-6d7e65073b56"
+version = "4.5.1"
+
+[[deps.NaNMath]]
+git-tree-sha1 = "f755f36b19a5116bb580de457cda0c140153f283"
+uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
+version = "0.3.6"
+
+[[deps.NearestNeighbors]]
+deps = ["Distances", "StaticArrays"]
+git-tree-sha1 = "16baacfdc8758bc374882566c9187e785e85c2f0"
+uuid = "b8a86587-4115-5ab1-83bc-aa920d37bbce"
+version = "0.4.9"
+
+[[deps.NetworkOptions]]
+uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+
+[[deps.OpenLibm_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+
+[[deps.OpenSpecFun_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "13652491f6856acfd2db29360e1bbcd4565d04f1"
+uuid = "efe28fd5-8261-553b-a9e1-b2916fc3738e"
+version = "0.5.5+0"
+
+[[deps.OrderedCollections]]
+git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
+uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
+version = "1.4.1"
+
+[[deps.Parameters]]
+deps = ["OrderedCollections", "UnPack"]
+git-tree-sha1 = "34c0e9ad262e5f7fc75b10a9952ca7692cfc5fbe"
+uuid = "d96e819e-fc66-5662-9728-84c9c7592b0a"
+version = "0.12.3"
+
+[[deps.Parsers]]
+deps = ["Dates"]
+git-tree-sha1 = "d7fa6237da8004be601e19bd6666083056649918"
+uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
+version = "2.1.3"
+
+[[deps.Pkg]]
+deps = ["Artifacts", "Dates", "Downloads", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "Serialization", "TOML", "Tar", "UUIDs", "p7zip_jll"]
+uuid = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
+[[deps.PolynomialBases]]
+deps = ["ArgCheck", "FastGaussQuadrature", "FastTransforms", "LinearAlgebra", "Requires", "SpecialFunctions", "UnPack"]
+git-tree-sha1 = "19e31b56245430abce92181e9bea508f65604341"
+uuid = "c74db56a-226d-5e98-8bb0-a6049094aeea"
+version = "0.4.11"
+
+[[deps.Polynomials]]
+deps = ["LinearAlgebra", "MutableArithmetics", "RecipesBase"]
+git-tree-sha1 = "0107e2f7f90cc7f756fee8a304987c574bbd7583"
+uuid = "f27b6e38-b328-58d1-80ce-0feddd5e7a45"
+version = "3.0.0"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "2cf929d64681236a2e074ffafb8d568733d2e6af"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.2.3"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[deps.Qhull_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4de074cc5e5f20d221694291dcd79d1b6ec1a104"
+uuid = "784f63db-0788-585a-bace-daefebcd302b"
+version = "2020.2.0+0"
+
+[[deps.QuadGK]]
+deps = ["DataStructures", "LinearAlgebra"]
+git-tree-sha1 = "78aadffb3efd2155af139781b8a8df1ef279ea39"
+uuid = "1fd47b50-473d-5c70-9696-f719f8f3bcdc"
+version = "2.4.2"
+
+[[deps.REPL]]
+deps = ["InteractiveUtils", "Markdown", "Sockets", "Unicode"]
+uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
+
+[[deps.Random]]
+deps = ["SHA", "Serialization"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+
+[[deps.RecipesBase]]
+git-tree-sha1 = "6bf3f380ff52ce0832ddd3a2a7b9538ed1bcca7d"
+uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
+version = "1.2.1"
+
+[[deps.Reexport]]
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
+uuid = "189a3867-3050-52da-a836-e630ba90ab69"
+version = "1.2.2"
+
+[[deps.Requires]]
+deps = ["UUIDs"]
+git-tree-sha1 = "838a3a4188e2ded87a4f9f184b4b0d78a1e91cb7"
+uuid = "ae029012-a4dd-5104-9daa-d747884805df"
+version = "1.3.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+
+[[deps.SharedArrays]]
+deps = ["Distributed", "Mmap", "Random", "Serialization"]
+uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
+
+[[deps.SimpleTraits]]
+deps = ["InteractiveUtils", "MacroTools"]
+git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
+uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
+version = "0.9.4"
+
+[[deps.Sockets]]
+uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
+
+[[deps.SortingAlgorithms]]
+deps = ["DataStructures"]
+git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
+uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
+version = "1.0.1"
+
+[[deps.SparseArrays]]
+deps = ["LinearAlgebra", "Random"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+
+[[deps.SparseMatricesCSR]]
+deps = ["LinearAlgebra", "SparseArrays", "SuiteSparse"]
+git-tree-sha1 = "4870b3e7db7063927b163fb981bd579410b68b2d"
+uuid = "a0a7dd2c-ebf4-11e9-1f05-cf50bc540ca1"
+version = "0.6.6"
+
+[[deps.SpecialFunctions]]
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "e08890d19787ec25029113e88c34ec20cac1c91e"
+uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
+version = "2.0.0"
+
+[[deps.Static]]
+deps = ["IfElse"]
+git-tree-sha1 = "b4912cd034cdf968e06ca5f943bb54b17b97793a"
+uuid = "aedffcd0-7271-4cad-89d0-dc628f76c6d3"
+version = "0.5.1"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "Random", "Statistics"]
+git-tree-sha1 = "88a559da57529581472320892576a486fa2377b9"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.3.1"
+
+[[deps.Statistics]]
+deps = ["LinearAlgebra", "SparseArrays"]
+uuid = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.StatsAPI]]
+git-tree-sha1 = "d88665adc9bcf45903013af0982e2fd05ae3d0a6"
+uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
+version = "1.2.0"
+
+[[deps.StatsBase]]
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "8977b17906b0a1cc74ab2e3a05faa16cf08a8291"
+uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
+version = "0.33.16"
+
+[[deps.SuiteSparse]]
+deps = ["Libdl", "LinearAlgebra", "Serialization", "SparseArrays"]
+uuid = "4607b0f0-06f3-5cda-b6b1-a6196a1729e9"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+
+[[deps.Tar]]
+deps = ["ArgTools", "SHA"]
+uuid = "a4e569a6-e804-4fa4-b0f3-eef7a1d5b13e"
+
+[[deps.Test]]
+deps = ["InteractiveUtils", "Logging", "Random", "Serialization"]
+uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+
+[[deps.ToeplitzMatrices]]
+deps = ["AbstractFFTs", "LinearAlgebra", "StatsBase"]
+git-tree-sha1 = "b61dc0269afe4c4e6109cee4d4098121bf59a8d0"
+uuid = "c751599d-da0a-543b-9d20-d0a503d91d24"
+version = "0.7.0"
+
+[[deps.TranscodingStreams]]
+deps = ["Random", "Test"]
+git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
+uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
+version = "0.9.6"
+
+[[deps.URIParser]]
+deps = ["Unicode"]
+git-tree-sha1 = "53a9f49546b8d2dd2e688d216421d050c9a31d0d"
+uuid = "30578b45-9adc-5946-b283-645ec420af67"
+version = "0.4.1"
+
+[[deps.UUIDs]]
+deps = ["Random", "SHA"]
+uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
+
+[[deps.UnPack]]
+git-tree-sha1 = "387c1f73762231e86e0c9c5443ce3b4a0a9a0c2b"
+uuid = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
+version = "1.0.2"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+
+[[deps.WriteVTK]]
+deps = ["Base64", "CodecZlib", "FillArrays", "LightXML", "TranscodingStreams"]
+git-tree-sha1 = "4642a7b953ed9f7f043bfba58b17d6c9722d09b2"
+uuid = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+version = "1.12.2"
+
+[[deps.XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "1acf5bdf07aa0907e0a37d3718bb88d4b687b74a"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.9.12+0"
+
+[[deps.Zlib_jll]]
+deps = ["Libdl"]
+uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl", "OpenBLAS_jll"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+
+[[deps.nghttp2_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+
+[[deps.p7zip_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "3f19e933-33d8-53b3-aaab-bd5110c3b7a0"

--- a/src/AgFEM/AgFEM.jl
+++ b/src/AgFEM/AgFEM.jl
@@ -7,19 +7,25 @@ using Gridap
 using Gridap.Helpers
 using Gridap.Arrays
 using Gridap.Geometry
+using Gridap.Geometry: get_cell_to_parent_cell
 using Gridap.ReferenceFEs
 using Gridap.CellData
 using Gridap.FESpaces
 
 using GridapEmbedded.CSG
 using GridapEmbedded.Interfaces
+using GridapEmbedded.Interfaces: compute_subcell_to_inout
 
 export aggregate
 export color_aggregates
 export AggregateAllCutCells
+export compute_cell_bboxes
+export compute_cell_to_dface_bboxes
 export AgFEMSpace
 
 include("CellAggregation.jl")
+
+include("AggregateBoundingBoxes.jl")
 
 include("AgFEMSpaces.jl")
 

--- a/src/AgFEM/AggregateBoundingBoxes.jl
+++ b/src/AgFEM/AggregateBoundingBoxes.jl
@@ -1,0 +1,173 @@
+function init_bboxes(cell_to_coords)
+  # RMK: Assuming first node is min and last node is max of BBox
+  [ [cell_to_coords[c][1],cell_to_coords[c][end]] for c in 1:length(cell_to_coords) ]
+end
+
+function init_bboxes(cell_to_coords,cut::EmbeddedDiscretization)
+  bgcell_to_cbboxes = init_bboxes(cell_to_coords)
+  cut_bgtrian = Triangulation(cut,CUT,cut.geo)
+  cut_bgmodel = get_active_model(cut_bgtrian)
+  ccell_to_bgcell = get_cell_to_parent_cell(cut_bgmodel)
+  ccell_to_cbboxes = init_cut_bboxes(cut,ccell_to_bgcell)
+  for (cc,cbb) in enumerate(ccell_to_cbboxes)
+    bgcell_to_cbboxes[ccell_to_bgcell[cc]] = cbb
+  end
+  bgcell_to_cbboxes
+end
+
+function init_cut_bboxes(cut,ccell_to_bgcell)
+  subcell_to_inout   = compute_subcell_to_inout(cut,cut.geo) # WARNING! This function has a bug
+  subcell_is_in      = lazy_map(i->i==IN,subcell_to_inout)
+  inscell_to_subcell = findall(subcell_is_in)
+  inscell_to_bgcell  = lazy_map(Reindex(cut.subcells.cell_to_bgcell),inscell_to_subcell)
+  inscell_to_bboxes  = init_subcell_bboxes(cut,inscell_to_subcell)
+  lazy_map(ccell_to_bgcell) do bg
+    bg_to_scs = findall(map(x->x==bg,inscell_to_bgcell))
+    bg_to_bbs = inscell_to_bboxes[bg_to_scs]
+    compute_bgcell_cut_bbox(bg_to_bbs)
+  end
+end
+
+function init_subcell_bboxes(cut,inscell_to_subcell)
+  subcell_to_points = lazy_map(Reindex(cut.subcells.cell_to_points),inscell_to_subcell)
+  point_to_coords   = cut.subcells.point_to_coords
+  subcell_to_coords = lazy_map(subcell_to_points) do points
+    point_to_coords[points]
+  end
+  lazy_map(compute_subcell_bbox,subcell_to_coords)
+end
+
+function compute_subcell_bbox(subcell_to_coords)
+  c(i) = map(x -> x[i],subcell_to_coords)
+  mins = [minimum(c(i)) for i in 1:length(first(subcell_to_coords))]
+  maxs = [maximum(c(i)) for i in 1:length(first(subcell_to_coords))]
+  [VectorValue(mins),VectorValue(maxs)]
+end
+
+function compute_bgcell_cut_bbox(bgcell_to_bboxes)
+  c = map(x -> x[1].data,bgcell_to_bboxes)
+  mins = min.(c...)
+  c = map(x -> x[2].data,bgcell_to_bboxes)
+  maxs = max.(c...)
+  [VectorValue(mins),VectorValue(maxs)]
+end
+
+function compute_bboxes!(root_to_agg_bbox,cell_to_root)
+  cell_to_bbox = root_to_agg_bbox
+  for (c,r) in enumerate(cell_to_root)
+    ( ( r == 0 ) | ( c == r ) ) && continue
+    bbmin = min.(root_to_agg_bbox[r][1].data,cell_to_bbox[c][1].data)
+    bbmax = max.(root_to_agg_bbox[r][2].data,cell_to_bbox[c][2].data)
+    root_to_agg_bbox[r] = [bbmin,bbmax]
+  end
+end
+
+function reset_bboxes_at_cut_cells!(root_to_agg_bbox,
+                                    cell_to_root,
+                                    cell_to_coords)
+  for (c,r) in enumerate(cell_to_root)
+    ( ( r == 0 ) | ( c == r ) ) && continue
+    root_to_agg_bbox[c] = [cell_to_coords[c][1],cell_to_coords[c][end]]
+  end
+end
+
+function compute_cell_bboxes(model::DiscreteModelPortion,cell_to_root)
+  compute_cell_bboxes(get_parent_model(model),cell_to_root)
+end
+
+function compute_cell_bboxes(model::DiscreteModel,cell_to_root)
+  trian = Triangulation(model)
+  compute_cell_bboxes(trian,cell_to_root)
+end
+
+function compute_cell_bboxes(trian::Triangulation,cell_to_root)
+  cell_to_coords = get_cell_coordinates(trian)
+  root_to_agg_bbox = init_bboxes(cell_to_coords)
+  compute_bboxes!(root_to_agg_bbox,cell_to_root)
+  reset_bboxes_at_cut_cells!(root_to_agg_bbox,cell_to_root,cell_to_coords)
+  root_to_agg_bbox
+end
+
+function compute_cell_bboxes(model::DiscreteModelPortion,cut::EmbeddedDiscretization,cell_to_root)
+  compute_cell_bboxes(get_parent_model(model),cut,cell_to_root)
+end
+
+function compute_cell_bboxes(model::DiscreteModel,cut::EmbeddedDiscretization,cell_to_root)
+  trian = Triangulation(model)
+  compute_cell_bboxes(trian,cut,cell_to_root)
+end
+
+function compute_cell_bboxes(trian::Triangulation,cut::EmbeddedDiscretization,cell_to_root)
+  cell_to_coords = get_cell_coordinates(trian)
+  root_to_agg_bbox = init_bboxes(cell_to_coords,cut)
+  compute_bboxes!(root_to_agg_bbox,cell_to_root)
+  reset_bboxes_at_cut_cells!(root_to_agg_bbox,cell_to_root,cell_to_coords)
+  root_to_agg_bbox
+end
+
+function compute_bbox_dfaces(model::DiscreteModel,cell_to_agg_bbox)
+  gt = get_grid_topology(model)
+  bboxes = Array{eltype(cell_to_agg_bbox),1}[]
+  D = num_dims(gt)
+  for d = 1:D-1
+    dface_to_Dfaces = get_faces(gt,d,D)
+    d_bboxes =
+      [ _compute_bbox_dface(dface_to_Dfaces,cell_to_agg_bbox,face) for face in 1:num_faces(gt,d) ]
+    bboxes = push!(bboxes,d_bboxes)
+  end
+  bboxes = push!(bboxes,cell_to_agg_bbox)
+end
+
+function _compute_bbox_dface(dface_to_Dfaces,cell_to_agg_bbox,i)
+  cells_around_dface_i = getindex(dface_to_Dfaces,i)
+  bboxes_around_dface_i = cell_to_agg_bbox[cells_around_dface_i]
+  bbmins = [ bboxes_around_dface_i[i][1].data for i in 1:length(bboxes_around_dface_i) ]
+  bbmaxs = [ bboxes_around_dface_i[i][2].data for i in 1:length(bboxes_around_dface_i) ]
+  [min.(bbmins...),max.(bbmaxs...)]
+end
+
+function _compute_cell_to_dface_bboxes(model::DiscreteModel,dbboxes)
+  gt = get_grid_topology(model)
+  trian = Triangulation(model)
+  ctc = get_cell_coordinates(trian)
+  bboxes = [ __compute_cell_to_dface_bboxes(gt,ctc,dbboxes,cell) for cell in 1:num_cells(model) ]
+  CellPoint(bboxes,trian,PhysicalDomain()).cell_ref_point
+end
+
+function __compute_cell_to_dface_bboxes(gt::GridTopology,ctc,dbboxes,cell::Int)
+  cdbboxes = eltype(eltype(eltype(dbboxes)))[]
+  D = num_dims(gt)
+  Dface_to_0faces = get_faces(gt,D,0)
+  for face in getindex(Dface_to_0faces,cell)
+    cdbboxes = vcat(cdbboxes,ctc[cell][1],ctc[cell][end])
+  end
+  for d = 1:D-1
+    Dface_to_dfaces = get_faces(gt,D,d)
+    for face in getindex(Dface_to_dfaces,cell)
+      cdbboxes = vcat(cdbboxes,dbboxes[d][face])
+    end
+  end
+  cdbboxes = vcat(cdbboxes,dbboxes[D][cell][1],dbboxes[D][cell][end])
+end
+
+function compute_cell_to_dface_bboxes(model::DiscreteModel,cell_to_root)
+  cbboxes = compute_cell_bboxes(model,cell_to_root)
+  dbboxes = compute_bbox_dfaces(model,cbboxes)
+  _compute_cell_to_dface_bboxes(model,dbboxes)
+end
+
+function compute_cell_to_dface_bboxes(model::DiscreteModelPortion,cell_to_root)
+  bboxes = compute_cell_to_dface_bboxes(get_parent_model(model),cell_to_root)
+  bboxes[get_cell_to_parent_cell(model)]
+end
+
+function compute_cell_to_dface_bboxes(model::DiscreteModel,cut::EmbeddedDiscretization,cell_to_root)
+  cbboxes = compute_cell_bboxes(model,cut,cell_to_root)
+  dbboxes = compute_bbox_dfaces(model,cbboxes)
+  _compute_cell_to_dface_bboxes(model,dbboxes)
+end
+
+function compute_cell_to_dface_bboxes(model::DiscreteModelPortion,cut::EmbeddedDiscretization,cell_to_root)
+  bboxes = compute_cell_to_dface_bboxes(get_parent_model(model),cut,cell_to_root)
+  bboxes[get_cell_to_parent_cell(model)]
+end

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -46,3 +46,5 @@ end
 @publish AgFEM color_aggregates
 @publish AgFEM AggregateCutCellsByThreshold
 @publish AgFEM AggregateAllCutCells
+@publish AgFEM compute_cell_bboxes
+@publish AgFEM compute_cell_to_dface_bboxes

--- a/test/GridapEmbeddedTests/PoissonModalC0AgFEMTests.jl
+++ b/test/GridapEmbeddedTests/PoissonModalC0AgFEMTests.jl
@@ -1,0 +1,77 @@
+module PoissonModalC0AgFEMTests
+
+  using Gridap
+  using GridapEmbedded
+  using Test
+
+  using GridapEmbedded.Interfaces: CUT, IN
+
+  u(x) = (x[1]+x[2])^3
+  f(x) = -Δ(u)(x)
+  ud(x) = u(x)
+
+  const R = 0.42
+
+  n = 6
+  order = 3
+
+  geom = disk(R,x0=Point(0.5,0.5))
+  partition = (n,n)
+  domain = (0,1,0,1)
+
+  bgmodel = CartesianDiscreteModel(domain,partition)
+  h = (domain[2]-domain[1])/n
+  cutgeo = cut(bgmodel,geom)
+
+  Ω_act = Triangulation(cutgeo,ACTIVE)
+  model = get_active_model(Ω_act)
+
+  strategy = AggregateAllCutCells()
+  aggregates = aggregate(strategy,cutgeo,geom)
+  bboxes = compute_cell_to_dface_bboxes(model,cutgeo,aggregates)
+
+  Ω_bg = Triangulation(bgmodel)
+  Ω = Triangulation(cutgeo,PHYSICAL)
+  Γ = EmbeddedBoundary(cutgeo)
+
+  n_Γ = get_normal_vector(Γ)
+
+  cutdeg, degree = 2*num_dims(model)*order, 2*order
+  dΩ = Measure(Ω,cutdeg,degree)
+  dΓ = Measure(Γ,cutdeg)
+
+  # reffe = ReferenceFE(lagrangian,Float64,order)
+  reffe = ReferenceFE(modalC0,Float64,order,bboxes)
+  Vstd = TestFESpace(Ω_act,reffe,conformity=:H1)
+  V = AgFEMSpace(Vstd,aggregates) # lagrangian
+  # V = AgFEMSpace(Vstd,aggregates,modalC0)
+  U = TrialFESpace(V)
+
+  γd = 5.0*order^2
+
+  a(u,v) =
+    ∫( ∇(v)⋅∇(u) )dΩ +
+    ∫( (γd/h)*v*u  - v*(n_Γ⋅∇(u)) - (n_Γ⋅∇(v))*u )dΓ
+
+  l(v) =
+    ∫( v*f )dΩ +
+    ∫( (γd/h)*v*ud - (n_Γ⋅∇(v))*ud )dΓ
+
+  op = AffineFEOperator(a,l,U,V)
+
+  uh = solve(op)
+ 
+  e = u - uh
+
+  l2(u) = sqrt(abs(sum( ∫( u*u )dΩ )))
+  h1(u) = sqrt(abs(sum( ∫( u*u + ∇(u)⋅∇(u) )dΩ )))
+
+  el2 = l2(e)
+  eh1 = h1(e)
+  ul2 = l2(uh)
+  uh1 = h1(uh)
+
+  @test el2/ul2 < 1.e-8
+  @test eh1/uh1 < 1.e-7
+
+end # module

--- a/test/GridapEmbeddedTests/runtests.jl
+++ b/test/GridapEmbeddedTests/runtests.jl
@@ -6,6 +6,8 @@ using Test
 
 @time @testset "PoissonAgFEM" begin include("PoissonAgFEMTests.jl") end
 
+@time @testset "PoissonModalC0AgFEM" begin include("PoissonModalC0AgFEMTests.jl") end
+
 @time @testset "BimaterialPoissonCutFEM" begin include("BimaterialPoissonCutFEMTests.jl") end
 
 @time @testset "EmbeddedBimaterialPoissonCutFEM" begin include("EmbeddedBimaterialPoissonCutFEMTests.jl") end


### PR DESCRIPTION
Hi, @santiagobadia,

This PR adds the machinery supporting generation of AgFEM Modal C0 spaces.

It basically consists of the algorithms that compute bounding boxes of aggregates.

As you can see, the changes are "practically" orthogonal to GridapEmbedded.

This PR depends on having Modal C0 bases and reffes in Gridap. 

Thus, I am leaving it in draft mode until we solve the PR of Modal C0 in Gridap.

Cheers!