### PR TITLE
Update `FillArrays` version to newest versions 

### DIFF
--- a/.github/workflows/ci_x86.yml
+++ b/.github/workflows/ci_x86.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.5'
+          - '1.6'
         os:
           - ubuntu-latest
         arch:

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@
 /docs/build/
 /docs/site/
 Manifest.toml
+.vscode/

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridapEmbedded"
 uuid = "8838a6a3-0006-4405-b874-385995508d5d"
 authors = ["Francesc Verdugo <fverdugo@cimne.upc.edu>"]
-version = "0.8.0"
+version = "0.8.1"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -17,7 +17,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 AbstractTrees = "0.3.3"
 Combinatorics = "1"
-FillArrays = "0.10, 0.11"
+FillArrays = "0.10, 0.11, 0.12, 0.13"
 Gridap = "0.17.13"
 LightGraphs = "1.3.3"
 MiniQhull = "0.1.0, 0.2, 0.3"


### PR DESCRIPTION
Updated `FillArrays` version to newest versions `0.12` and `0.13` in `Project.toml` and bumped up the `GridapEmbedded` patch version to `0.8.1` as per @amartinhuertas suggestion. This was to resolve some version compatibility issues with other external packages.  