### PR TITLE
Set compat for AbstractTrees as in Gridap

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,7 +15,7 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-AbstractTrees = "0.3.3"
+AbstractTrees = "0.3.3, 0.4"
 Combinatorics = "1"
 FillArrays = "0.10, 0.11, 0.12, 0.13"
 Gridap = "0.17.13"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -9,7 +9,6 @@ makedocs(;
     repo="https://github.com/gridap/GridapEmbedded.jl/blob/{commit}{path}#L{line}",
     sitename="GridapEmbedded.jl",
     authors="Francesc Verdugo <fverdugo@cimne.upc.edu>",
-    assets=String[],
 )
 
 deploydocs(;

--- a/src/Interfaces/Cutters.jl
+++ b/src/Interfaces/Cutters.jl
@@ -1,8 +1,5 @@
 abstract type Cutter <: GridapType end
 
-"""
-    cut(cutter::Cutter,background,geom) -> EmbeddedDiscretization
-"""
 function cut(cutter::Cutter,background,geom)
   @abstractmethod
 end
@@ -11,9 +8,6 @@ function compute_bgcell_to_inoutcut(cutter::Cutter,background,geom)
   @abstractmethod
 end
 
-"""
-    cut_facets(cutter::Cutter,background,geom) -> EmbeddedDiscretization
-"""
 function cut_facets(cutter::Cutter,background,geom)
   @abstractmethod
 end


### PR DESCRIPTION
AbstractTrees v0.3 is incompatible with latest versions of SymbolicUtils (see https://github.com/JuliaSymbolics/SymbolicUtils.jl/pull/564).

Letting GE use AbstractTrees v0.4, as in Gridap, s.t. it can be composed with SymbolicUtils.