### PR TITLE
Bump version 0.9.2

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.2] - 2024-04-26
+
+### Added
+- Distributed extension of the cutters and aggregation. The distributed methods work on top of [GridapDistributed.jl](https://github.com/gridap/GridapDistributed.jl) and [PartitionedArrays.jl](https://github.com/fverdugo/PartitionedArrays.jl). Since PR [#81](https://github.com/gridap/GridapEmbedded.jl/pull/81).
+
 ## [0.9.1] - 2024-04-12
 
 ### Changed

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridapEmbedded"
 uuid = "8838a6a3-0006-4405-b874-385995508d5d"
 authors = ["Francesc Verdugo <f.verdugo.rojano@vu.nl>", "Eric Neiva <eric.neiva@college-de-france.fr>", "Santiago Badia <santiago.badia@monash.edu>"]
-version = "0.9.1"
+version = "0.9.2"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/src/Interfaces/EmbeddedDiscretizations.jl
+++ b/src/Interfaces/EmbeddedDiscretizations.jl
@@ -253,7 +253,7 @@ end
 function Triangulation(cut::EmbeddedDiscretization,in_or_out::Tuple,geo::CSG.Geometry)
   trian1 = Triangulation(cut,in_or_out[1],geo)
   trian2 = Triangulation(cut,in_or_out[2],geo)
-  lazy_append(trian1,trian2)
+  num_cells(trian1) == 0 ? trian2 : lazy_append(trian1,trian2)
 end
 
 function Triangulation(cut::EmbeddedDiscretization,in_or_out::CutInOrOut,geo::CSG.Geometry)

--- a/src/Interfaces/EmbeddedFacetDiscretizations.jl
+++ b/src/Interfaces/EmbeddedFacetDiscretizations.jl
@@ -128,7 +128,8 @@ function BoundaryTriangulation(
 
   trian1 = BoundaryTriangulation(facets,cut,in_or_out[1],geo)
   trian2 = BoundaryTriangulation(facets,cut,in_or_out[2],geo)
-  lazy_append(trian1,trian2)
+  num_cells(trian1) == 0 ? trian2 : lazy_append(trian1,trian2)
+
 end
 
 function BoundaryTriangulation(


### PR DESCRIPTION
@santiagobadia @ericneiva 

this PR is a setup for the new release with the developments of #81. Therefore, you can publish a new release after merging.


Note that the distributed extension has the following limitations or pending developments:

- MomentFitted quadratures are not yet distributed
- Bounding Boxes aggregation is not yet distributed
- Algoims is not tested with distributed
- Integration and assembly may fail with empty subdomains (current limitation of Gridap/GridapDistributed)