### PR TITLE
Remove spurious `export` and `@publish` of non-existing `fill_cpp_data_raw`

### DIFF
--- a/src/AlgoimUtils/AlgoimUtils.jl
+++ b/src/AlgoimUtils/AlgoimUtils.jl
@@ -38,7 +38,6 @@ export Quadrature
 export is_cell_active
 export restrict_measure
 export fill_cpp_data
-export fill_cpp_data_raw
 export compute_closest_point_projections
 export compute_normal_displacement
 export compute_normal_displacement!

--- a/src/Exports.jl
+++ b/src/Exports.jl
@@ -56,7 +56,6 @@ end
 @publish AlgoimUtils TriangulationAndMeasure
 @publish AlgoimUtils normal
 @publish AlgoimUtils fill_cpp_data
-@publish AlgoimUtils fill_cpp_data_raw
 @publish AlgoimUtils compute_closest_point_projections
 @publish AlgoimUtils compute_normal_displacement
 @publish AlgoimUtils compute_normal_displacement!


### PR DESCRIPTION
The current version breaks during `precompile` stage as it has a spurious `export` and `@publish` of a non-existing method `fill_cpp_data_raw`. Just removing the two respective lines fixes this.

This was what I grabbed out of a CI build using `GridapEmbedded`:
```
ERROR: LoadError: UndefVarError: `fill_cpp_data_raw` not defined
Stacktrace:
 [1] top-level scope
   @ ~/.julia/packages/GridapEmbedded/r8izR/src/Exports.jl:4
...
```