### PR TITLE
Adding redistribute flags and adaptive weights

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Adding `compute_redistribute_weights` and `compute_adaptive_flags` functions for load balancing and adaptive mesh refinement, respectively. Since PR [#95](https://github.com/gridap/GridapEmbedded.jl/pull/95).
+
+
 ## [0.9.4] - 2024-07-09
 
 ### Added

--- a/src/Distributed/DistributedDiscretizations.jl
+++ b/src/Distributed/DistributedDiscretizations.jl
@@ -339,3 +339,56 @@ function remove_ghost_subfacets(cut::EmbeddedFacetDiscretization,facet_gids)
     cut.oid_to_ls,
     cut.geo)
 end
+
+function compute_redistribute_wights(
+  cut::DistributedEmbeddedDiscretization,
+  args...)
+
+  geo = get_geometry(cut)
+  compute_redistribute_wights(cut,geo,args...)
+end
+
+function compute_redistribute_wights(
+  cut::DistributedEmbeddedDiscretization,
+  geo::CSG.Geometry,
+  args...)
+
+  compute_redistribute_wights(compute_bgcell_to_inoutcut(cut,geo),args...)
+end
+
+function compute_redistribute_wights(cell_to_inoutcut,in_or_out=IN)
+  map(cell_to_inoutcut) do cell_to_inoutcut
+    map(cell_to_inoutcut) do inoutcut
+      Int( inoutcut ∈ (CUT,in_or_out) )
+    end
+  end
+end
+
+function compute_adaptive_flags(
+  cut::DistributedEmbeddedDiscretization,
+  args...)
+
+  geo = get_geometry(cut)
+  compute_adaptive_flags(cut,geo,args...)
+end
+
+function compute_adaptive_flags(
+  cut::DistributedEmbeddedDiscretization,
+  geo::CSG.Geometry,
+  args...)
+
+  compute_adaptive_flags(compute_bgcell_to_inoutcut(cut,geo),args...)
+end
+
+function compute_adaptive_flags(cell_to_inoutcut)
+  map(cell_to_inoutcut) do c_to_ioc
+    flags = zeros(Cint,length(c_to_ioc))
+    flags .= nothing_flag
+    for (c,ioc) in enumerate(c_to_ioc)
+      if ioc == CUT
+        flags[c] = refine_flag
+      end
+    end
+    flags
+  end
+end


### PR DESCRIPTION
Adding 
* `compute_redistribute_flags`
* `compute_adaptive_weights`

for load balancing and adaptive mesh refinement, resp. These functions return `flags` and `weighs` to be used in `Gridap.Adaptivity.Adapt` and `GridapDistributed.redistribute`, resp.

Such features are implemented for `p4est` meshes. These functions are not tested in order to avoid adding `GridapP4est` as a dependency.

See the usage in STLCutters [documentation](https://gridap.github.io/STLCutters.jl/dev/distributed/)