### PR TITLE
add kwargs to Triangulations in distributed (required for tags in BoundaryTriangulation)

### DIFF
--- a/src/Distributed/DistributedDiscretizations.jl
+++ b/src/Distributed/DistributedDiscretizations.jl
@@ -86,18 +86,19 @@ function SkeletonTriangulation(cutgeo::DistributedEmbeddedDiscretization,args...
   remove_ghost_cells(trian)
 end
 
-function BoundaryTriangulation(cutgeo::DistributedEmbeddedDiscretization,args...)
-  trian = distributed_embedded_triangulation(BoundaryTriangulation,cutgeo,args...)
+function BoundaryTriangulation(cutgeo::DistributedEmbeddedDiscretization,args...;kwargs...)
+  trian = distributed_embedded_triangulation(BoundaryTriangulation,cutgeo,args...;kwargs...)
   remove_ghost_cells(trian)
 end
 
 function distributed_embedded_triangulation(
   T,
   cutgeo::DistributedEmbeddedDiscretization,
-  args...)
+  args...;
+  kwargs...)
 
   trians = map(local_views(cutgeo)) do lcutgeo
-    T(lcutgeo,args...)
+    T(lcutgeo,args...;kwargs...)
   end
   bgmodel = get_background_model(cutgeo)
   DistributedTriangulation(trians,bgmodel)


### PR DESCRIPTION
Adding `kwargs...` to https://github.com/gridap/GridapEmbedded.jl/blob/6850b686cc41cf5a018436377fc35efa63e60ed2/src/Distributed/DistributedDiscretizations.jl#L63C1-L89C4 so it is possible to pass the keyword argument `tags` present in `BoundaryTriangulation` in https://github.com/gridap/GridapEmbedded.jl/blob/6850b686cc41cf5a018436377fc35efa63e60ed2/src/Interfaces/EmbeddedFacetDiscretizations.jl#L72C1-L122C1 