### PR TITLE
add kwargs to Triangulations in distributed (required for tags in BoundaryTriangulation)

### DIFF
--- a/src/Distributed/DistributedDiscretizations.jl
+++ b/src/Distributed/DistributedDiscretizations.jl
@@ -61,28 +61,28 @@ end
 # when we have the argument `in_or_out`.
 
 function Triangulation(
-  cutgeo::DistributedEmbeddedDiscretization,in_or_out::ActiveInOrOut,args...
+  cutgeo::DistributedEmbeddedDiscretization,in_or_out::ActiveInOrOut,args...;kwargs...
 )
-  Triangulation(WithGhost(),cutgeo,in_or_out,args...)
+  Triangulation(WithGhost(),cutgeo,in_or_out,args...;kwargs...)
 end
 
 for TT in (:Triangulation,:SkeletonTriangulation,:BoundaryTriangulation,:EmbeddedBoundary,:GhostSkeleton)
   @eval begin
-    function $TT(cutgeo::DistributedEmbeddedDiscretization,args...)
-      $TT(NoGhost(),cutgeo,args...)
+    function $TT(cutgeo::DistributedEmbeddedDiscretization,args...;kwargs...)
+      $TT(NoGhost(),cutgeo,args...;kwargs...)
     end
 
-    function $TT(portion,cutgeo::DistributedEmbeddedDiscretization,args...)
+    function $TT(portion,cutgeo::DistributedEmbeddedDiscretization,args...;kwargs...)
       model = get_background_model(cutgeo)
       gids  = get_cell_gids(model)
       trians = map(local_views(cutgeo),partition(gids)) do cutgeo, gids
-        $TT(portion,gids,cutgeo,args...)
+        $TT(portion,gids,cutgeo,args...;kwargs...)
       end
       DistributedTriangulation(trians,model)
     end
 
-    function $TT(portion,gids::AbstractLocalIndices,cutgeo::AbstractEmbeddedDiscretization,args...)
-      trian = $TT(cutgeo,args...)
+    function $TT(portion,gids::AbstractLocalIndices,cutgeo::AbstractEmbeddedDiscretization,args...;kwargs...)
+      trian = $TT(cutgeo,args...;kwargs...)
       filter_cells_when_needed(portion,gids,trian)
     end
   end


### PR DESCRIPTION
Adding `kwargs...` to https://github.com/gridap/GridapEmbedded.jl/blob/6850b686cc41cf5a018436377fc35efa63e60ed2/src/Distributed/DistributedDiscretizations.jl#L63C1-L89C4 so it is possible to pass the keyword argument `tags` present in `BoundaryTriangulation` in https://github.com/gridap/GridapEmbedded.jl/blob/6850b686cc41cf5a018436377fc35efa63e60ed2/src/Interfaces/EmbeddedFacetDiscretizations.jl#L72C1-L122C1