### PR TITLE
Distributed BoundaryTriangulation + typo on compute_redistribute_weights

### DIFF
--- a/src/Distributed/Distributed.jl
+++ b/src/Distributed/Distributed.jl
@@ -20,6 +20,7 @@ using GridapEmbedded.Interfaces
 using GridapEmbedded.Interfaces: Cutter
 using GridapEmbedded.Interfaces: ActiveInOrOut
 using GridapEmbedded.Interfaces: SubFacetTriangulation
+using GridapEmbedded.Interfaces: SubFacetBoundaryTriangulation
 using GridapEmbedded.Interfaces: SubCellData
 using GridapEmbedded.Interfaces: SubFacetData
 using GridapEmbedded.Interfaces: AbstractEmbeddedDiscretization

--- a/src/Distributed/DistributedDiscretizations.jl
+++ b/src/Distributed/DistributedDiscretizations.jl
@@ -191,23 +191,23 @@ end
 
 # AMR
 
-function compute_redistribute_wights(
+function compute_redistribute_weights(
   cut::DistributedEmbeddedDiscretization,
   args...)
 
   geo = get_geometry(cut)
-  compute_redistribute_wights(cut,geo,args...)
+  compute_redistribute_weights(cut,geo,args...)
 end
 
-function compute_redistribute_wights(
+function compute_redistribute_weights(
   cut::DistributedEmbeddedDiscretization,
   geo::CSG.Geometry,
   args...)
 
-  compute_redistribute_wights(compute_bgcell_to_inoutcut(cut,geo),args...)
+  compute_redistribute_weights(compute_bgcell_to_inoutcut(cut,geo),args...)
 end
 
-function compute_redistribute_wights(cell_to_inoutcut,in_or_out=IN)
+function compute_redistribute_weights(cell_to_inoutcut,in_or_out=IN)
   map(cell_to_inoutcut) do cell_to_inoutcut
     map(cell_to_inoutcut) do inoutcut
       Int( inoutcut ∈ (CUT,in_or_out) )


### PR DESCRIPTION
Adding kwargs so BoundaryTriangulation(cutgeofacets,...;tags) is passed, added SubFacetBoundaryTriangulation to Distributed and typo in function name