### PR TITLE
Geometrical derivatives

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@
 /docs/build/
 /docs/site/
 Manifest.toml
+LocalPreferences.toml
 .vscode/
 *.swp

--- a/NEWS.md
+++ b/NEWS.md
@@ -10,6 +10,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added support for distributed level-set geometries. Since PR[#99](https://github.com/gridap/GridapEmbedded.jl/pull/99).
 - Refactored the distributed code to allow for ghosted/unghosted geometries and triangulations. Since PR[#100](https://github.com/gridap/GridapEmbedded.jl/pull/100).
+- Implemented geometrical derivatives. Since PR[#109](https://github.com/gridap/GridapEmbedded.jl/pull/109).
+- Added a proper documentation. Since PR[#109](https://github.com/gridap/GridapEmbedded.jl/pull/109).
 
 ### Changed
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.9.6] - 2025-04-19
 
 ### Added
 

--- a/Project.toml
+++ b/Project.toml
@@ -9,6 +9,7 @@ Algoim = "0eb9048c-21de-4c7a-bfac-056de1940b74"
 Combinatorics = "861a8166-3701-5b0c-9a16-15d98fcdc6aa"
 CxxWrap = "1f15a43c-97ca-5a2a-ae31-89f07a497df4"
 FillArrays = "1a297f60-69ca-5386-bcde-b61e274b549b"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 Graphs = "86223c79-3864-5bf0-83f7-82e725a168b6"
 Gridap = "56d4f2e9-7ea1-5844-9cf6-b9c51ca7ce8e"
 GridapDistributed = "f9701e48-63b3-45aa-9a63-9bc6c271f355"
@@ -26,6 +27,8 @@ Algoim = "0.2.2"
 Combinatorics = "1"
 CxxWrap = "0.16"
 FillArrays = "0.10, 0.11, 0.12, 0.13, 1"
+FiniteDiff = "2.27.0"
+ForwardDiff = "0.10.38"
 Graphs = "1.12.0"
 Gridap = "0.17, 0.18"
 GridapDistributed = "0.3, 0.4"
@@ -35,7 +38,8 @@ PartitionedArrays = "0.3.4"
 julia = "1.3"
 
 [extras]
+FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Test","FiniteDiff"]

--- a/Project.toml
+++ b/Project.toml
@@ -30,7 +30,7 @@ FillArrays = "0.10, 0.11, 0.12, 0.13, 1"
 FiniteDiff = "2.27.0"
 ForwardDiff = "0.10.38"
 Graphs = "1.12.0"
-Gridap = "0.17, 0.18"
+Gridap = "0.18.12"
 GridapDistributed = "0.3, 0.4"
 MPI = "0.20"
 MiniQhull = "0.1.0, 0.2, 0.3, 0.4"
@@ -42,4 +42,4 @@ FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test","FiniteDiff"]
+test = ["Test", "FiniteDiff"]

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "GridapEmbedded"
 uuid = "8838a6a3-0006-4405-b874-385995508d5d"
 authors = ["Francesc Verdugo <f.verdugo.rojano@vu.nl>", "Eric Neiva <eric.neiva@college-de-france.fr>", "Pere Antoni Martorell <pere.antoni.martorell@upc.edu>", "Santiago Badia <santiago.badia@monash.edu>"]
-version = "0.9.5"
+version = "0.9.6"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,23 @@
+authors = ["Francesc Verdugo <f.verdugo.rojano@vu.nl>", "Eric Neiva <eric.neiva@college-de-france.fr>", "Pere Antoni Martorell <pere.antoni.martorell@upc.edu>", "Santiago Badia <santiago.badia@monash.edu>"]
 name = "GridapEmbedded"
 uuid = "8838a6a3-0006-4405-b874-385995508d5d"
-authors = ["Francesc Verdugo <f.verdugo.rojano@vu.nl>", "Eric Neiva <eric.neiva@college-de-france.fr>", "Pere Antoni Martorell <pere.antoni.martorell@upc.edu>", "Santiago Badia <santiago.badia@monash.edu>"]
 version = "0.9.6"
+
+[compat]
+AbstractTrees = "0.3.3, 0.4"
+Algoim = "0.2.2"
+Combinatorics = "1"
+CxxWrap = "0.16"
+FillArrays = "0.10, 0.11, 0.12, 0.13, 1"
+FiniteDiff = "2.27.0"
+ForwardDiff = "0.10.38, 1"
+Graphs = "1.12.0"
+Gridap = "0.18.12"
+GridapDistributed = "0.3, 0.4"
+MPI = "0.20"
+MiniQhull = "0.1.0, 0.2, 0.3, 0.4"
+PartitionedArrays = "0.3.4"
+julia = "1.3"
 
 [deps]
 AbstractTrees = "1520ce14-60c1-5f80-bbc7-55ef81b5835c"
@@ -21,24 +37,9 @@ Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 algoimWrapper_jll = "3c43aa7b-5398-51f3-8d75-8f051e6faa4d"
 
-[compat]
-AbstractTrees = "0.3.3, 0.4"
-Algoim = "0.2.2"
-Combinatorics = "1"
-CxxWrap = "0.16"
-FillArrays = "0.10, 0.11, 0.12, 0.13, 1"
-FiniteDiff = "2.27.0"
-ForwardDiff = "0.10.38"
-Graphs = "1.12.0"
-Gridap = "0.18.12"
-GridapDistributed = "0.3, 0.4"
-MPI = "0.20"
-MiniQhull = "0.1.0, 0.2, 0.3, 0.4"
-PartitionedArrays = "0.3.4"
-julia = "1.3"
-
 [extras]
 FiniteDiff = "6a86dc24-6348-571c-b903-95158fe2bd41"
+MPIPreferences = "3da0fdf6-3ccc-4f1b-acd9-58baa6c99267"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 Embedded finite element methods, level set surface descriptions and constructive solid geometry.
 
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://gridap.github.io/GridapEmbedded.jl/stable)
 [![Build Status](https://github.com/gridap/GridapEmbedded.jl/workflows/CI/badge.svg?branch=master)](https://github.com/gridap/GridapEmbedded.jl/actions?query=workflow%3ACI)
 [![Codecov](https://codecov.io/gh/gridap/GridapEmbedded.jl/branch/master/graph/badge.svg)](https://codecov.io/gh/gridap/GridapEmbedded.jl)
 
@@ -40,4 +41,3 @@ julia> BimaterialLinElastCutFEM.main(n=4,outputfile="results3")
 ```
 
 <img src="https://raw.githubusercontent.com/gridap/GridapEmbedded.jl/master/examples/BimaterialLinElastCutFEM/BimaterialLinElastCutFEM_solution.png" width="400">
-

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,2 +1,3 @@
 [deps]
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
+GridapEmbedded = "8838a6a3-0006-4405-b874-385995508d5d"

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -1,14 +1,24 @@
 using Documenter, GridapEmbedded
 
+pages = [
+    "Home" => "index.md",
+    "Interfaces" => "Interfaces.md",
+    "Constructive Solid Geometry (CSG)" => "CSGCutters.md",
+    "Level Sets" => "LevelSetCutters.md",
+    "Aggregated FEM" => "AggregatedFEM.md",
+    "Moment-Fitted Quadratures" => "MomentFittedQuadratures.md",
+    "Distributed computing" => "Distributed.md",
+],
+
 makedocs(;
-    modules=[GridapEmbedded],
-    format=Documenter.HTML(),
-    pages=[
-        "Home" => "index.md",
-    ],
-    repo="https://github.com/gridap/GridapEmbedded.jl/blob/{commit}{path}#L{line}",
-    sitename="GridapEmbedded.jl",
-    authors="Francesc Verdugo <f.verdugo.rojano@vu.nl>, Eric Neiva <eric.neiva@college-de-france.fr> and Santiago Badia <santiago.badia@monash.edu>",
+    modules = [GridapEmbedded],
+    format = Documenter.HTML(
+        size_threshold=nothing
+    ),
+    sitename = "GridapEmbedded.jl",
+    authors = "Francesc Verdugo <f.verdugo.rojano@vu.nl>, Eric Neiva <eric.neiva@college-de-france.fr> and Santiago Badia <santiago.badia@monash.edu>",
+    pages = pages,
+    warnonly = true,
 )
 
 deploydocs(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -2,9 +2,9 @@ using Documenter, GridapEmbedded
 
 pages = [
     "Home" => "index.md",
-    "Interfaces" => "Interfaces.md",
-    "Constructive Solid Geometry (CSG)" => "CSGCutters.md",
-    "Level Sets" => "LevelSetCutters.md",
+    "Constructive Solid Geometry (CSG)" => "CSG.md",
+    "Embedded Interfaces" => "Interfaces.md",
+    "Level Set Cutters" => "LevelSetCutters.md",
     "Aggregated FEM" => "AggregatedFEM.md",
     "Moment-Fitted Quadratures" => "MomentFittedQuadratures.md",
     "Distributed computing" => "Distributed.md",

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,6 +7,7 @@ pages = [
     "Level Set Cutters" => "LevelSetCutters.md",
     "Aggregated FEM" => "AggregatedFEM.md",
     "Moment-Fitted Quadratures" => "MomentFittedQuadratures.md",
+    "Geometrical Derivatives" => "GeometricalDerivatives.md",
     "Distributed computing" => "Distributed.md",
 ]
 
@@ -18,7 +19,7 @@ makedocs(;
     sitename = "GridapEmbedded.jl",
     authors = "Francesc Verdugo <f.verdugo.rojano@vu.nl>, Eric Neiva <eric.neiva@college-de-france.fr> and Santiago Badia <santiago.badia@monash.edu>",
     pages = pages,
-    warnonly = true,
+    warnonly = false,
 )
 
 deploydocs(;

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ pages = [
     "Aggregated FEM" => "AggregatedFEM.md",
     "Moment-Fitted Quadratures" => "MomentFittedQuadratures.md",
     "Distributed computing" => "Distributed.md",
-],
+]
 
 makedocs(;
     modules = [GridapEmbedded],

--- a/docs/src/AggregatedFEM.md
+++ b/docs/src/AggregatedFEM.md
@@ -1,0 +1,16 @@
+
+# Aggregated FEM
+
+```@meta
+CurrentModule = GridapEmbedded.AgFEM
+```
+
+```@autodocs
+Modules = [AgFEM,]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/AgFEM.jl", 
+  "/AgFEMSpaces.jl",
+  "CellAggregation.jl" 
+]
+```

--- a/docs/src/CSG.md
+++ b/docs/src/CSG.md
@@ -1,5 +1,5 @@
 
-# Constructive Solid Geometry (CSG) Cutters
+# Constructive Solid Geometry (CSG)
 
 ```@meta
 CurrentModule = GridapEmbedded.CSG

--- a/docs/src/CSGCutters.md
+++ b/docs/src/CSGCutters.md
@@ -1,0 +1,15 @@
+
+# Constructive Solid Geometry (CSG) Cutters
+
+```@meta
+CurrentModule = GridapEmbedded.CSG
+```
+
+```@autodocs
+Modules = [CSG,]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/Nodes.jl", 
+  "/Geometries.jl", 
+]
+```

--- a/docs/src/Distributed.md
+++ b/docs/src/Distributed.md
@@ -1,0 +1,11 @@
+
+# Distributed computing
+
+```@meta
+CurrentModule = GridapEmbedded.Distributed
+```
+
+```@autodocs
+Modules = [Distributed,]
+Order   = [:type, :constant, :macro, :function]
+```

--- a/docs/src/Distributed.md
+++ b/docs/src/Distributed.md
@@ -5,6 +5,18 @@
 CurrentModule = GridapEmbedded.Distributed
 ```
 
+We support distributed computing through [GridapDistributed.jl](https://github.com/gridap/GridapDistributed.jl). As per usual, we design our libraries so that the high-level API is unchanged when using distributed computing. This means that for most users, the changes to your driver will be minimal.
+
+The following features are currently supported:
+
+- Level-Set Cutters
+- STL Cutters
+
+The folowing features are not yet supported:
+
+- Aggregated FEM
+- Moment-Fitted Quadratures
+
 ```@autodocs
 Modules = [Distributed,]
 Order   = [:type, :constant, :macro, :function]

--- a/docs/src/GeometricalDerivatives.md
+++ b/docs/src/GeometricalDerivatives.md
@@ -8,7 +8,7 @@ The geometrical differentiation capabilities are based on the following work:
 
 !!! note "Reference"
     "Level-set topology optimisation with unfitted finite elements and automatic shape differentiation",
-    by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis, CMAME (2025)
+    by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis (2025)
 
 To see examples of usage, please refer to the tests in `test/LevelSetCuttersTests/GeometricalDifferentiationTests.jl`.
 

--- a/docs/src/GeometricalDerivatives.md
+++ b/docs/src/GeometricalDerivatives.md
@@ -1,0 +1,33 @@
+# Geometrical Derivatives
+
+```@meta
+CurrentModule = GridapEmbedded
+```
+
+The geometrical differentiation capabilities are based on the following work:
+
+!!! note "Reference"
+    "Level-set topology optimisation with unfitted finite elements and automatic shape differentiation",
+    by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis, CMAME (2025)
+
+To see examples of usage, please refer to the tests in `test/LevelSetCuttersTests/GeometricalDifferentiationTests.jl`.
+
+## Discretize then differentiate
+
+```@autodocs
+Modules = [GridapEmbedded.Interfaces]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/CutFaceBoundaryTriangulations.jl", 
+]
+```
+
+## Autodiff
+
+```@autodocs
+Modules = [GridapEmbedded.LevelSetCutters]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/DifferentiableTriangulations.jl", 
+]
+```

--- a/docs/src/Interfaces.md
+++ b/docs/src/Interfaces.md
@@ -1,0 +1,48 @@
+
+# Embedded Interfaces
+
+```@meta
+CurrentModule = GridapEmbedded.Interfaces
+```
+
+## Cutters
+
+Cutters are used to cut the background mesh according to a provided geometry.
+
+```@autodocs
+Modules = [Interfaces,]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/Cutters.jl", 
+]
+```
+
+We provide several types of cutters, including:
+
+- **CSG Cutters**: Constructive Solid Geometry (CSG) Cutters. See [Constructive Solid Geometry (CSG) Cutters](@ref).
+- **Level-Set Cutters**: Level-Set Cutters. See [Level-Set Cutters](@ref).
+- **STL Cutters**: Cutters for STL based geometries. Provided by [STLCutters.jl](https://github.com/gridap/STLCutters.jl).
+
+## Embedded Discretizations
+
+After cutting the background mesh, you will be returned an `EmbeddedDiscretization` object. These contain all the information you need to generate the integration meshes for embedded methods.
+
+```@autodocs
+Modules = [Interfaces,]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/EmbeddedDiscretizations.jl", 
+  "/EmbeddedFacetDiscretizations.jl", 
+]
+```
+
+## Embedded Triangulations
+
+```@autodocs
+Modules = [Interfaces,]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/SubCellTriangulations", 
+  "/SubFacetTriangulations.jl"
+]
+```

--- a/docs/src/Interfaces.md
+++ b/docs/src/Interfaces.md
@@ -5,6 +5,45 @@
 CurrentModule = GridapEmbedded.Interfaces
 ```
 
+## Domain Nomenclature
+
+Throughout this documentation, many methods accept arguments that select different parts of the cut domain. We split the domain into the following parts:
+
+The background mesh entities (cells, facets, nodes) are classified as `IN`, `OUT` or `CUT`. The `IN` and `OUT` background cells are uncut, i.e completely inside or outside the geometry, respectively. These states are internally defined as constants:
+
+```julia
+  const IN = -1
+  const OUT = 1
+  const CUT = 0
+```
+
+The `CUT` background cells are cut by the embedded boundary, and split into subcells/subfacets. The subcells/subfacets are classified as `IN` or `OUT` depending on whether they are inside or outside the geometry. `CUT-IN` and `CUT-OUT` subentities can be accessed using the `CutInOrOut` objects:
+
+```julia
+  struct CutInOrOut
+    in_or_out::Int
+  end
+  const CUT_IN = CutInOrOut(IN)
+  const CUT_OUT = CutInOrOut(OUT)
+```
+
+For FEM, we generally want to get sets of uncut and cut cells together, for a given state `IN/OUT`. These are referred as `PHYSICAL` parts of the domain. Moreover, FE spaces are generally defined over the background mesh and need to span both `IN/OUT` and `CUT` background cells. These are referred as `ACTIVE` parts of the domain. You can extract the `PHYSICAL` and `ACTIVE` parts of the domain using the following constants:
+
+```julia
+const PHYSICAL_IN = (CUT_IN,IN)
+const PHYSICAL_OUT = (CUT_OUT,OUT)
+const PHYSICAL = PHYSICAL_IN
+```
+
+```julia
+struct ActiveInOrOut
+  in_or_out::Int
+end
+const ACTIVE_IN = ActiveInOrOut(IN)
+const ACTIVE_OUT = ActiveInOrOut(OUT)
+const ACTIVE = ACTIVE_IN
+```
+
 ## Cutters
 
 Cutters are used to cut the background mesh according to a provided geometry.
@@ -27,22 +66,21 @@ We provide several types of cutters, including:
 
 After cutting the background mesh, you will be returned an `EmbeddedDiscretization` object. These contain all the information you need to generate the integration meshes for embedded methods.
 
-```@autodocs
-Modules = [Interfaces,]
-Order   = [:type, :constant, :macro, :function]
-Pages   = [
-  "/EmbeddedDiscretizations.jl", 
-  "/EmbeddedFacetDiscretizations.jl", 
-]
+```@docs
+AbstractEmbeddedDiscretization
+EmbeddedDiscretization
+EmbeddedFacetDiscretization
 ```
 
 ## Embedded Triangulations
 
-```@autodocs
-Modules = [Interfaces,]
-Order   = [:type, :constant, :macro, :function]
-Pages   = [
-  "/SubCellTriangulations", 
-  "/SubFacetTriangulations.jl"
-]
+From `EmbeddedDiscretization` objects, you can extract all the triangulations you need to perform integration for embedded methods. We currently provide the following methods:
+
+```@docs
+Gridap.Geometry.Triangulation(::EmbeddedDiscretization,::Any)
+EmbeddedBoundary(::EmbeddedDiscretization)
+GhostSkeleton(::EmbeddedDiscretization)
+Gridap.Geometry.BoundaryTriangulation(::EmbeddedFacetDiscretization,::Any)
+Gridap.Geometry.SkeletonTriangulation(::EmbeddedFacetDiscretization,::Any)
+SubFacetBoundaryTriangulation
 ```

--- a/docs/src/Interfaces.md
+++ b/docs/src/Interfaces.md
@@ -81,5 +81,7 @@ EmbeddedBoundary(::EmbeddedDiscretization)
 GhostSkeleton(::EmbeddedDiscretization)
 Gridap.Geometry.BoundaryTriangulation(::EmbeddedFacetDiscretization,::Any)
 Gridap.Geometry.SkeletonTriangulation(::EmbeddedFacetDiscretization,::Any)
+SubCellTriangulation
+SubFacetTriangulation
 SubFacetBoundaryTriangulation
 ```

--- a/docs/src/Interfaces.md
+++ b/docs/src/Interfaces.md
@@ -9,7 +9,7 @@ CurrentModule = GridapEmbedded.Interfaces
 
 Throughout this documentation, many methods accept arguments that select different parts of the cut domain. We split the domain into the following parts:
 
-The background mesh entities (cells, facets, nodes) are classified as `IN`, `OUT` or `CUT`. The `IN` and `OUT` background cells are uncut, i.e completely inside or outside the geometry, respectively. These states are internally defined as constants:
+**The background mesh entities** (cells, facets, nodes) are classified as `IN`, `OUT` or `CUT`. The `IN` and `OUT` background cells are uncut, i.e completely inside or outside the geometry, respectively. These states are internally defined as constants:
 
 ```julia
   const IN = -1
@@ -17,7 +17,7 @@ The background mesh entities (cells, facets, nodes) are classified as `IN`, `OUT
   const CUT = 0
 ```
 
-The `CUT` background cells are cut by the embedded boundary, and split into subcells/subfacets. The subcells/subfacets are classified as `IN` or `OUT` depending on whether they are inside or outside the geometry. `CUT-IN` and `CUT-OUT` subentities can be accessed using the `CutInOrOut` objects:
+**The `CUT` background cells** are cut by the embedded boundary, and split into subcells/subfacets. The subcells/subfacets are classified as `IN` or `OUT` depending on whether they are inside or outside the geometry. `CUT_IN` and `CUT_OUT` subentities can be accessed using the `CutInOrOut` objects:
 
 ```julia
   struct CutInOrOut
@@ -58,8 +58,7 @@ Pages   = [
 
 We provide several types of cutters, including:
 
-- **CSG Cutters**: Constructive Solid Geometry (CSG) Cutters. See [Constructive Solid Geometry (CSG) Cutters](@ref).
-- **Level-Set Cutters**: Level-Set Cutters. See [Level-Set Cutters](@ref).
+- **Level-Set Cutters**: Cutters for Level-Set and function-defined geometries. See [Level-Set Cutters](@ref).
 - **STL Cutters**: Cutters for STL based geometries. Provided by [STLCutters.jl](https://github.com/gridap/STLCutters.jl).
 
 ## Embedded Discretizations

--- a/docs/src/LevelSetCutters.md
+++ b/docs/src/LevelSetCutters.md
@@ -1,0 +1,16 @@
+
+# Level-Set Cutters
+
+```@meta
+CurrentModule = GridapEmbedded.LevelSetCutters
+```
+
+```@autodocs
+Modules = [LevelSetCutters,]
+Order   = [:type, :constant, :macro, :function]
+Pages   = [
+  "/AnalyticalGeometries.jl",
+  "/DiscreteGeometries.jl",
+  "LevelSetCutters.jl", 
+]
+```

--- a/docs/src/MomentFittedQuadratures.md
+++ b/docs/src/MomentFittedQuadratures.md
@@ -1,0 +1,11 @@
+
+# Moment-Fitted Quadratures
+
+```@meta
+CurrentModule = GridapEmbedded.MomentFittedQuadratures
+```
+
+```@autodocs
+Modules = [MomentFittedQuadratures,]
+Order   = [:type, :constant, :macro, :function]
+```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,6 +13,7 @@ Pages = [
   "LevelSetCutters.md",
   "AggregatedFEM.md",
   "MomentFittedQuadratures.md",
+  "GeometricalDerivatives.md",
   "Distributed.md",
 ]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,8 +1,18 @@
 # GridapEmbedded.jl
 
-```@index
-```
+## Introduction
 
-```@autodocs
-Modules = [GridapEmbedded]
+GridapEmbedded.jl is a package for the simulation of PDEs on embedded domains within the Gridap.jl ecosystem. Please refer to the [Gridap.jl documentation](https://gridap.github.io/Gridap.jl/stable/) for information on the core capabilities of the Gridap.jl library.
+
+## Manual
+
+```@contents
+Pages = [
+  "Interfaces.md",
+  "CSGCutters.md",
+  "LevelSetCutters.md",
+  "AggregatedFEM.md",
+  "MomentFittedQuadratures.md",
+  "Distributed.md",
+]
 ```

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -8,8 +8,8 @@ GridapEmbedded.jl is a package for the simulation of PDEs on embedded domains wi
 
 ```@contents
 Pages = [
+  "CSG.md",
   "Interfaces.md",
-  "CSGCutters.md",
   "LevelSetCutters.md",
   "AggregatedFEM.md",
   "MomentFittedQuadratures.md",

--- a/src/CSG/Geometries.jl
+++ b/src/CSG/Geometries.jl
@@ -1,14 +1,35 @@
 
+"""
+    abstract type Geometry
+
+Abstract type for the definition of a geometry.
+
+## Interface
+
+- `get_tree(geo::Geometry)`
+- `similar_geometry(a::Geometry,tree::Node)`
+- `compatible_geometries(a::Geometry,b::Geometry)`
+
+"""
 abstract type Geometry end
 
+"""
+    get_tree(geo::Geometry)
+"""
 function get_tree(geo::Geometry)
   @abstractmethod
 end
 
+"""
+    similar_geometry(a::Geometry,tree::Node)
+"""
 function similar_geometry(a::Geometry,tree::Node)
   @abstractmethod
 end
 
+"""
+    compatible_geometries(a::Geometry,b::Geometry)
+"""
 function compatible_geometries(a::Geometry,b::Geometry)
   @abstractmethod
 end
@@ -51,24 +72,36 @@ function _replace_metadata(tree::Leaf,meta)
   Leaf(data)
 end
 
+"""
+    Base.union(a::Geometry,b::Geometry;name::String="",meta=nothing)
+"""
 function Base.union(a::Geometry,b::Geometry;name::String="",meta=nothing)
   _a, _b = compatible_geometries(a,b)
   tree = union(get_tree(_a),get_tree(_b),name,meta)
   similar_geometry(_a,tree)
 end
 
+"""
+    Base.intersect(a::Geometry,b::Geometry;name::String="",meta=nothing)
+"""
 function Base.intersect(a::Geometry,b::Geometry;name::String="",meta=nothing)
   _a, _b = compatible_geometries(a,b)
   tree = intersect(get_tree(_a),get_tree(_b),name,meta)
   similar_geometry(_a,tree)
 end
 
+"""
+    Base.setdiff(a::Geometry,b::Geometry;name::String="",meta=nothing)
+"""
 function Base.setdiff(a::Geometry,b::Geometry;name::String="",meta=nothing)
   _a, _b = compatible_geometries(a,b)
   tree = setdiff(get_tree(_a),get_tree(_b),name,meta)
   similar_geometry(_a,tree)
 end
 
+"""
+    Base.:!(a::Geometry;name::String="",meta=nothing)
+"""
 function Base.:!(a::Geometry;name::String="",meta=nothing)
   tree = !(get_tree(a),name,meta)
   similar_geometry(a,tree)
@@ -119,5 +152,3 @@ function get_geometry_node(a::Node,name::String)
   end
   @unreachable "There is no entity called $name"
 end
-
-

--- a/src/Distributed/Distributed.jl
+++ b/src/Distributed/Distributed.jl
@@ -60,6 +60,7 @@ import Gridap.Geometry: Triangulation
 import Gridap.Geometry: SkeletonTriangulation
 import Gridap.Geometry: BoundaryTriangulation
 import Gridap.Geometry: get_background_model
+import Gridap.Geometry: num_cells
 import Gridap.CellData: get_tangent_vector
 import GridapDistributed: local_views
 import GridapDistributed: remove_ghost_cells

--- a/src/Distributed/Distributed.jl
+++ b/src/Distributed/Distributed.jl
@@ -31,6 +31,7 @@ using GridapEmbedded.MomentFittedQuadratures: MomentFitted
 using GridapEmbedded.LevelSetCutters: DifferentiableTriangulation
 using GridapEmbedded.LevelSetCutters: DifferentiableAppendedTriangulation
 using GridapEmbedded.LevelSetCutters: DifferentiableTriangulationView
+using GridapEmbedded.LevelSetCutters: update_trian!
 using Gridap.Geometry: AppendedTriangulation, TriangulationView
 using Gridap.Geometry: get_face_to_parent_face
 using Gridap.Arrays: find_inverse_index_map, testitem, return_type

--- a/src/Distributed/Distributed.jl
+++ b/src/Distributed/Distributed.jl
@@ -23,9 +23,14 @@ using GridapEmbedded.Interfaces: SubFacetTriangulation
 using GridapEmbedded.Interfaces: SubCellData
 using GridapEmbedded.Interfaces: SubFacetData
 using GridapEmbedded.Interfaces: AbstractEmbeddedDiscretization
+using GridapEmbedded.Interfaces: CutFaceBoundaryTriangulation
+using GridapEmbedded.Interfaces: CutFaceSkeletonTriangulation
 using GridapEmbedded.AgFEM: _touch_aggregated_cells!
 using GridapEmbedded.AgFEM: AggregateCutCellsByThreshold
 using GridapEmbedded.MomentFittedQuadratures: MomentFitted
+using GridapEmbedded.LevelSetCutters: DifferentiableTriangulation
+using GridapEmbedded.LevelSetCutters: DifferentiableAppendedTriangulation
+using GridapEmbedded.LevelSetCutters: DifferentiableTriangulationView
 using Gridap.Geometry: AppendedTriangulation, TriangulationView
 using Gridap.Geometry: get_face_to_parent_face
 using Gridap.Arrays: find_inverse_index_map, testitem, return_type
@@ -34,6 +39,7 @@ using Gridap.FESpaces: _dof_to_DOF, _DOF_to_dof
 
 using GridapDistributed: DistributedDiscreteModel, DistributedTriangulation, DistributedMeasure
 using GridapDistributed: DistributedFESpace, DistributedSingleFieldFESpace
+using GridapDistributed: DistributedCellField, DistributedMultiFieldCellField
 using GridapDistributed: NoGhost, WithGhost, filter_cells_when_needed, add_ghost_cells
 using GridapDistributed: generate_gids, generate_cell_gids
 using GridapDistributed: _find_vector_type
@@ -46,12 +52,14 @@ import GridapEmbedded.Interfaces: EmbeddedBoundary
 import GridapEmbedded.Interfaces: compute_bgfacet_to_inoutcut
 import GridapEmbedded.Interfaces: compute_bgcell_to_inoutcut
 import GridapEmbedded.Interfaces: GhostSkeleton
+import GridapEmbedded.Interfaces: get_subfacet_normal_vector, get_ghost_normal_vector, get_conormal_vector
 import GridapEmbedded.CSG: get_geometry
 import GridapEmbedded.LevelSetCutters: discretize, DiscreteGeometry
 import Gridap.Geometry: Triangulation
 import Gridap.Geometry: SkeletonTriangulation
 import Gridap.Geometry: BoundaryTriangulation
 import Gridap.Geometry: get_background_model
+import Gridap.CellData: get_tangent_vector
 import GridapDistributed: local_views
 import GridapDistributed: remove_ghost_cells
 
@@ -64,5 +72,7 @@ include("DistributedSubFacetTriangulations.jl")
 include("DistributedAgFEM.jl")
 
 include("DistributedQuadratures.jl")
+
+include("GeometricalDerivatives.jl")
 
 end # module

--- a/src/Distributed/DistributedDiscretizations.jl
+++ b/src/Distributed/DistributedDiscretizations.jl
@@ -89,6 +89,12 @@ for TT in (:Triangulation,:SkeletonTriangulation,:BoundaryTriangulation,:Embedde
 end
 
 # TODO: This should go to GridapDistributed
+function get_tangent_vector(a::DistributedTriangulation)
+  fields = map(get_tangent_vector,local_views(a))
+  DistributedCellField(fields,a)
+end
+
+# TODO: This should go to GridapDistributed
 function remove_ghost_cells(trian::AppendedTriangulation,gids)
   a = remove_ghost_cells(trian.a,gids)
   b = remove_ghost_cells(trian.b,gids)

--- a/src/Distributed/DistributedDiscretizations.jl
+++ b/src/Distributed/DistributedDiscretizations.jl
@@ -92,7 +92,9 @@ end
 function remove_ghost_cells(trian::AppendedTriangulation,gids)
   a = remove_ghost_cells(trian.a,gids)
   b = remove_ghost_cells(trian.b,gids)
-  lazy_append(a,b)
+  iszero(num_cells(a)) && return b
+  iszero(num_cells(b)) && return a
+  return lazy_append(a,b)
 end
 
 function remove_ghost_cells(trian::SubFacetTriangulation{Df,Dc},gids) where {Df,Dc}

--- a/src/Distributed/DistributedSubFacetTriangulations.jl
+++ b/src/Distributed/DistributedSubFacetTriangulations.jl
@@ -8,34 +8,33 @@ function GridapDistributed.generate_cell_gids(
 ) where {Df,Dc}
   model = get_background_model(trian)
   cgids = get_cell_gids(model)
-  
-  n_lfacets = map(num_cells,local_views(trian))
-  first_gid = scan(+,n_lfacets,type=:exclusive,init=one(eltype(n_lfacets)))
-  n_facets = reduce(+,n_lfacets,init=zero(eltype(n_lfacets)))
 
-  fgids = map(local_views(trian),partition(cgids),first_gid,n_lfacets) do trian, cgids, first_gid, n_lfacets
-    glue = get_glue(trian,Val(Dc)) # Glue from cut facets to background cells 
-    facet_to_bgcell = glue.tface_to_mface
+  n_lfacets, bgcell_to_lfacets = map(local_views(trian)) do trian
+    model = get_background_model(trian)
+    lfacet_to_bgcell = get_glue(trian,Val(Dc)).tface_to_mface
+    n_lfacets = length(lfacet_to_bgcell)
 
-    facet_to_gid = collect(first_gid:(first_gid+n_lfacets-1))
-    facet_to_owner = local_to_owner(cgids)[facet_to_bgcell]
-    LocalIndices(n_facets,part_id(cgids),facet_to_gid,facet_to_owner)
-  end
-  return PRange(fgids)
+    ptrs  = zeros(Int32,num_cells(model)+1)
+    for bgcell in lfacet_to_bgcell
+      ptrs[bgcell+1] += 1
+    end
+    Arrays.length_to_ptrs!(ptrs)
+    @assert ptrs[end] == n_lfacets+1
+
+    data = zeros(Int32,n_lfacets)
+    for (lfacet,bgcell) in enumerate(lfacet_to_bgcell)
+      data[ptrs[bgcell]] = lfacet
+      ptrs[bgcell] += 1
+    end
+    Arrays.rewind_ptrs!(ptrs)
+
+    return n_lfacets, Table(data,ptrs)
+  end |> tuple_of_arrays
+
+  return GridapDistributed.generate_gids(
+    cgids, bgcell_to_lfacets, n_lfacets
+  )
 end
-
-# function GridapDistributed.generate_cell_gids(
-#   trian::DistributedSubFacetTriangulation{Df,Dc},
-# ) where {Df,Dc}
-#   model = get_background_model(trian)
-#   ctrians = map(local_views(trian),local_views(model)) do trian, model
-#     glue = get_glue(trian,Val(Dc)) # Glue from cut facets to background cells 
-#     facet_to_bgcell = glue.tface_to_mface
-#     Triangulation(model,facet_to_bgcell)
-#   end
-#   ctrian = GridapDistributed.DistributedTriangulation(ctrians,model)
-#   return GridapDistributed.generate_cell_gids(ctrian)
-# end
 
 function GridapDistributed.add_ghost_cells(
   trian::DistributedSubFacetTriangulation{Df,Dc},

--- a/src/Distributed/DistributedSubFacetTriangulations.jl
+++ b/src/Distributed/DistributedSubFacetTriangulations.jl
@@ -24,6 +24,19 @@ function GridapDistributed.generate_cell_gids(
   return PRange(fgids)
 end
 
+# function GridapDistributed.generate_cell_gids(
+#   trian::DistributedSubFacetTriangulation{Df,Dc},
+# ) where {Df,Dc}
+#   model = get_background_model(trian)
+#   ctrians = map(local_views(trian),local_views(model)) do trian, model
+#     glue = get_glue(trian,Val(Dc)) # Glue from cut facets to background cells 
+#     facet_to_bgcell = glue.tface_to_mface
+#     Triangulation(model,facet_to_bgcell)
+#   end
+#   ctrian = GridapDistributed.DistributedTriangulation(ctrians,model)
+#   return GridapDistributed.generate_cell_gids(ctrian)
+# end
+
 function GridapDistributed.add_ghost_cells(
   trian::DistributedSubFacetTriangulation{Df,Dc},
 ) where {Df,Dc}

--- a/src/Distributed/GeometricalDerivatives.jl
+++ b/src/Distributed/GeometricalDerivatives.jl
@@ -1,0 +1,56 @@
+
+
+function remove_ghost_cells(
+  trian::Union{<:CutFaceBoundaryTriangulation,<:CutFaceSkeletonTriangulation},gids
+)
+  model = get_background_model(trian)
+  Dm    = num_cell_dims(model)
+  glue  = get_glue(trian,Val(Dm))
+  remove_ghost_cells(glue,trian,gids)
+end
+
+for func in (:get_subfacet_normal_vector,:get_ghost_normal_vector,:get_conormal_vector)
+  @eval begin
+    function $func(a::DistributedTriangulation)
+      fields = map($func,local_views(a))
+      DistributedCellField(fields,a)
+    end
+  end
+end
+
+function LevelSetCutters.DifferentiableTriangulation(trian::DistributedTriangulation,fe_space)
+  model = get_background_model(trian)
+  trians = map(DifferentiableTriangulation,local_views(trian),local_views(fe_space))
+  return DistributedTriangulation(trians,model)
+end
+
+function FESpaces._change_argument(
+  op,f,
+  local_trians::AbstractArray{<:Union{<:DifferentiableTriangulation,<:DifferentiableAppendedTriangulation,<:DifferentiableTriangulationView}},
+  uh::GridapDistributed.DistributedADTypes
+)
+  function dist_cf(uh::DistributedCellField,cfs)
+    DistributedCellField(cfs,get_triangulation(uh))
+  end
+  function dist_cf(uh::DistributedMultiFieldCellField,cfs)
+    sf_cfs = map(DistributedCellField,
+      [tuple_of_arrays(map(cf -> Tuple(cf.single_fields),cfs))...],
+      map(get_triangulation,uh)
+    )
+    DistributedMultiFieldCellField(sf_cfs,cfs)
+  end
+
+  uhs = local_views(uh)
+  spaces = map(get_fe_space,uhs)
+  function g(cell_u)
+    cfs = map(CellField,spaces,cell_u)
+    cf = dist_cf(uh,cfs)
+    map(update_trian!,local_trians,spaces,local_views(cf))
+    cg = f(cf)
+    map(local_trians,spaces) do Ω, V
+      update_trian!(Ω,V,nothing)
+    end
+    map(get_contribution,local_views(cg),local_trians)
+  end
+  g
+end

--- a/src/Interfaces/CutFaceBoundaryTriangulations.jl
+++ b/src/Interfaces/CutFaceBoundaryTriangulations.jl
@@ -111,7 +111,7 @@ Triangulation containing the interfaces between subfacets. We always have dimens
   - Df = Dc-1 :: Dimension of the cut subfacets
   - Di = Dc-2 :: Dimension of the subfacet interfaces
 
-Description of the different components:
+# Properties
 
 - `face_trian` :: Original SubFacetTriangulation, built on top of the background mesh.
 - `face_model` :: Subfacet model. Active model for `face_trian`.

--- a/src/Interfaces/CutFaceBoundaryTriangulations.jl
+++ b/src/Interfaces/CutFaceBoundaryTriangulations.jl
@@ -1,0 +1,455 @@
+
+# Ghost triangulations
+
+function generate_ghost_trian(
+  trian::CompositeTriangulation, bgmodel
+)
+  Dc = num_cell_dims(bgmodel)
+  cell_glue = get_glue(trian,Val(Dc))
+  return generate_ghost_trian(trian,bgmodel,cell_glue)
+end
+
+function generate_ghost_trian(
+  trian::CompositeTriangulation, bgmodel, cell_glue::SkeletonPair{<:FaceToFaceGlue}
+)
+  Dc = num_cell_dims(bgmodel)
+  topo = get_grid_topology(bgmodel)
+  face_to_cell = get_faces(topo,Dc-1,Dc)
+  cell_to_face = get_faces(topo,Dc,Dc-1)
+
+  n_bgfaces = num_faces(bgmodel,Dc-1)
+  n_faces = num_cells(trian)
+  ghost_faces = zeros(Int32,n_faces)
+  p_lcell = ones(Int8,n_bgfaces)
+  m_lcell = ones(Int8,n_bgfaces)
+  for (i,(p_cell, m_cell)) in enumerate(zip(cell_glue.plus.tface_to_mface,cell_glue.minus.tface_to_mface))
+    inter = intersect(cell_to_face[p_cell],cell_to_face[m_cell])
+    @assert length(inter) == 1
+    face = first(inter)
+    ghost_faces[i] = face
+
+    nbors = face_to_cell[ghost_faces[i]]
+    p_lcell[face] = findfirst(==(p_cell),nbors)
+    m_lcell[face] = findfirst(==(m_cell),nbors)
+  end
+
+  plus = BoundaryTriangulation(bgmodel,ghost_faces,p_lcell)
+  minus = BoundaryTriangulation(bgmodel,ghost_faces,m_lcell)
+  return SkeletonTriangulation(plus,minus)
+end
+
+function generate_ghost_trian(
+  trian::CompositeTriangulation, bgmodel, cell_glue::FaceToFaceGlue
+)
+  Dc = num_cell_dims(bgmodel)
+  topo = get_grid_topology(bgmodel)
+  face_to_cell = get_faces(topo,Dc-1,Dc)
+  cell_to_face = get_faces(topo,Dc,Dc-1)
+  is_boundary(f) = isone(length(view(face_to_cell,f)))
+
+  n_faces = num_cells(trian)
+  ghost_faces = zeros(Int32,n_faces)
+  for (i,cell) in enumerate(cell_glue.tface_to_mface)
+    faces = filter(is_boundary,view(cell_to_face,cell))
+    @assert length(faces) == 1 # TODO: This will break if we are in a corner
+    face = first(faces)
+    ghost_faces[i] = face
+  end
+
+  # NOTE: lcell is always 1 for boundary facets
+  return BoundaryTriangulation(bgmodel,ghost_faces)
+end
+
+"""
+    get_ghost_mask(
+      face_trian::SubFacetTriangulation{Df,Dc},
+      face_model = get_active_model(face_trian)
+    ) where {Df,Dc}
+
+Returns a mask for ghost faces. We define ghost faces as the interfaces between two
+different cut facets that are located in different background cells.
+
+The second condition is important: In 3D, some cuts subcells may not be simplices.
+In this case, we simplexify the subcell. This creates extra cut interfaces that are
+interior to a background cell. These are not considered ghost faces.
+
+- In 2D: Dc = 2, Df = 1 -> Ghost faces have dimension 0 (i.e interface points)
+- In 3D: Dc = 3, Df = 2 -> Ghost faces have dimension 1 (i.e interface edges)
+"""
+function get_ghost_mask(
+  face_trian::SubFacetTriangulation{Df,Dc},
+  face_model = get_active_model(face_trian)
+) where {Df,Dc}
+  topo = get_grid_topology(face_model)
+  face_to_facets = get_faces(topo,Df-1,Df)
+
+  subfacets = face_trian.subfacets
+  facet_to_bgcell = subfacets.facet_to_bgcell
+
+  n_faces = num_faces(topo,Df-1)
+  face_is_ghost = zeros(Bool,n_faces)
+  for face in 1:n_faces
+    facets = view(face_to_facets,face)
+    is_boundary = isone(length(facets))
+    if !is_boundary
+      @assert length(facets) == 2
+      bgcells = view(facet_to_bgcell,facets)
+      is_ghost = (bgcells[1] != bgcells[2])
+      face_is_ghost[face] = is_ghost
+    end
+  end
+
+  return face_is_ghost
+end
+
+"""
+    struct CutFaceBoundaryTriangulation{Di,Df,Dp} <: Triangulation{Di,Dp}
+
+Triangulation containing the interfaces between subfacets. We always have dimensions
+
+  - Dc :: Dimension of the background mesh
+  - Df = Dc-1 :: Dimension of the cut subfacets
+  - Di = Dc-2 :: Dimension of the subfacet interfaces
+
+Description of the different components:
+
+- `face_trian` :: Original SubFacetTriangulation, built on top of the background mesh.
+- `face_model` :: Subfacet model. Active model for `face_trian`.
+- `face_boundary` :: Triangulation of the interfaces between subfacets. It is glued to the `face_model`.
+- `cell_boundary` :: Conceptually the same as `face_boundary`, but it is glued to the
+  background mesh cells. Created as a CompositeTriangulation between `face_trian` and `face_boundary`.
+- `ghost_boundary` :: Triangulation of the background facets that contain each interface.
+
+The "real" triangulation is `cell_boundary`, but we require the other triangulations to
+perform complex changes of domain. Most of the `Triangulation` API is delegated to `cell_boundary`.
+
+## Constructors
+
+    Boundary(face_trian::SubFacetTriangulation)
+    Skeleton(face_trian::SubFacetTriangulation)
+
+"""
+struct CutFaceBoundaryTriangulation{Di,Df,Dp} <: Triangulation{Di,Dp}
+  face_model     :: UnstructuredDiscreteModel{Df,Dp}
+  face_trian     :: SubFacetTriangulation{Df,Dp}  # Cut Facet -> BG Cell
+  cell_boundary  :: CompositeTriangulation{Di,Dp} # Interface -> BG Cell
+  face_boundary  :: BoundaryTriangulation{Di,Dp}  # Interface -> Cut Facet
+  ghost_boundary :: BoundaryTriangulation{Df,Dp}  # Ghost Facet -> BG Cell
+  interface_sign :: AbstractArray{<:Number}
+end
+
+function BoundaryTriangulation(face_trian::SubFacetTriangulation)
+  bgmodel = get_background_model(face_trian)
+  face_model = get_active_model(face_trian)
+
+  face_boundary  = BoundaryTriangulation(face_model)
+  cell_boundary  = CompositeTriangulation(face_trian,face_boundary)
+  ghost_boundary = generate_ghost_trian(cell_boundary,bgmodel)
+  interface_sign = get_interface_sign(cell_boundary,face_trian,ghost_boundary)
+
+  return CutFaceBoundaryTriangulation(
+    face_model,face_trian,cell_boundary,face_boundary,ghost_boundary,interface_sign
+  )
+end
+
+function get_background_model(t::CutFaceBoundaryTriangulation)
+  get_background_model(t.cell_boundary)
+end
+
+function get_active_model(t::CutFaceBoundaryTriangulation)
+  get_active_model(t.cell_boundary)
+end
+
+function get_grid(t::CutFaceBoundaryTriangulation)
+  get_grid(t.cell_boundary)
+end
+
+# Domain changes
+
+function get_glue(ttrian::CutFaceBoundaryTriangulation{Di,Df,Dp},::Val{D}) where {D,Di,Df,Dp}
+  get_glue(ttrian.cell_boundary,Val(D))
+end
+
+function is_change_possible(
+  strian::SubFacetTriangulation,ttrian::CutFaceBoundaryTriangulation
+)
+  return strian === ttrian.face_trian
+end
+
+function CellData.change_domain(
+  a::CellField,ttrian::CutFaceBoundaryTriangulation,tdomain::DomainStyle
+)
+  strian = get_triangulation(a)
+  if strian === ttrian
+    # 1) CellField defined on the skeleton
+    return change_domain(a,DomainStyle(a),tdomain)
+  end
+
+  if is_change_possible(strian,ttrian.cell_boundary)
+    # 2) CellField defined on the bgmodel
+    b = change_domain(a,ttrian.cell_boundary,tdomain)
+  elseif strian === ttrian.face_trian
+    # 3) CellField defined on the cut facets
+    itrian = Triangulation(ttrian.face_model)
+    _a = CellData.similar_cell_field(a,CellData.get_data(a),itrian,DomainStyle(a))
+    b = change_domain(_a,ttrian.face_boundary,tdomain)
+  else
+    @notimplemented
+  end
+  return CellData.similar_cell_field(b,CellData.get_data(b),ttrian,DomainStyle(b))
+end
+
+function CellData.change_domain(
+  f::CellData.OperationCellField,ttrian::CutFaceBoundaryTriangulation,tdomain::DomainStyle
+)
+  args = map(i->change_domain(i,ttrian,tdomain),f.args)
+  CellData.OperationCellField(f.op,args...)
+end
+
+# Normal vector to the cut facets , n_∂Ω
+function get_subfacet_normal_vector(trian::CutFaceBoundaryTriangulation)
+  n_∂Ω = get_subfacet_facet_normal(trian.cell_boundary,trian.face_trian)
+  return GenericCellField(n_∂Ω,trian,ReferenceDomain())
+end
+
+# Normal vector to the ghost facets, n_k
+function get_ghost_normal_vector(trian::CutFaceBoundaryTriangulation)
+  n = get_ghost_facet_normal(trian.cell_boundary,trian.ghost_boundary)
+  return GenericCellField(n,trian,ReferenceDomain())
+end
+
+# Orientation of the interface
+function get_interface_sign(trian::CutFaceBoundaryTriangulation)
+  data = lazy_map(constant_field,trian.interface_sign)
+  return GenericCellField(data,trian,ReferenceDomain())
+end
+
+# TODO: This is only valid when dealing with linear meshes (where normals are constant over facets).
+# If we wanted to use higher-order meshes, we would need to generate the geometric map
+# going from the facets to the interfaces.
+# However, having a high-order background mesh seems quite silly.
+function get_ghost_facet_normal(
+  itrian::CompositeTriangulation{Di,Dc}, # Interface -> BG Cell
+  gtrian::BoundaryTriangulation{Df,Dc}   # Ghost Facet -> BG Cell
+) where {Di,Df,Dc}
+  n_g = get_facet_normal(gtrian)
+  n_i = lazy_map(evaluate,n_g,Fill(zero(VectorValue{Df,Float64}),num_cells(itrian)))
+  return lazy_map(constant_field,n_i)
+end
+
+# This one would be fine for higher-order meshes.
+function get_subfacet_facet_normal(
+  itrian::CompositeTriangulation{Di,Dc}, # Interface -> BG Cell
+  ftrian::SubFacetTriangulation{Df,Dc},  # Cut Facet -> BG Cell
+) where {Di,Df,Dc}
+  glue = get_glue(itrian.dtrian,Val(Df))
+  i_to_f_ids = glue.tface_to_mface
+  i_to_f_map = glue.tface_to_mface_map
+  n_f = lazy_map(Reindex(get_facet_normal(ftrian)),i_to_f_ids)
+  n_i = lazy_map(Broadcasting(∘),n_f,i_to_f_map)
+  return n_i
+end
+
+# There is still something sweaty about this...
+# Why do we apply the sign change but at the same time call `get_edge_tangents` in the
+# creation of conormal vectors in 3D? It's like we are cancelling the sign change...
+# There is more to think about here.
+function get_interface_sign(
+  itrian::CompositeTriangulation{Di,Dc}, # Interface -> BG Cell
+  ftrian::SubFacetTriangulation{Df,Dc},  # Cut Facet -> BG Cell
+  gtrian::BoundaryTriangulation{Df,Dc},  # Ghost Facet -> BG Cell
+) where {Di,Df,Dc}
+  function signdot(a,b)
+    s = sign(dot(a,b))
+    return ifelse(iszero(s),1,s)
+  end
+  n_∂Ω = get_subfacet_facet_normal(itrian,ftrian)
+  n_k = get_ghost_facet_normal(itrian,gtrian)
+  if Di == 0
+    cross2D(n) = VectorValue(-n[2],n[1])
+    n_S = lazy_map(Operation(cross2D),n_k)
+  else
+    t_S = get_edge_tangents(itrian.dtrian)
+    n_S = lazy_map(Operation(cross),n_k,t_S)
+  end
+  sgn = lazy_map(Operation(signdot),n_∂Ω,n_S)
+  return collect(lazy_map(evaluate,sgn,Fill(zero(VectorValue{Di,Float64}),num_cells(itrian))))
+end
+
+function get_edge_tangents(trian::BoundaryTriangulation{1})
+  function t(c)
+    @assert length(c) == 2
+    t = c[2] - c[1]
+    return t/norm(t)
+  end
+  return lazy_map(constant_field,lazy_map(t,get_cell_coordinates(trian)))
+end
+
+function get_edge_tangents(trian::CutFaceBoundaryTriangulation{1})
+  data = get_edge_tangents(trian.face_boundary)
+  return GenericCellField(data,trian,ReferenceDomain())
+end
+
+# Normal vector to the cut interface, n_S
+function get_normal_vector(trian::CutFaceBoundaryTriangulation{Di}) where {Di}
+  n_k = get_ghost_normal_vector(trian)
+  isign = get_interface_sign(trian)
+  if Di == 0 # 2D
+    cross2D(n) = VectorValue(-n[2],n[1])
+    n_S = Operation(cross2D)(n_k) # nS = nk x tS and tS = ±e₃ in 2D
+  elseif Di == 1 # 3D
+    t_S = get_edge_tangents(trian)
+    n_S = Operation(cross)(n_k,t_S) # nk = tS x nS -> nS = nk x tS (eq 6.25)
+  else
+    @notimplemented
+  end
+  return n_S * isign
+end
+
+get_facet_normal(trian::CutFaceBoundaryTriangulation) = get_data(get_normal_vector(trian))
+
+# Tangent vector to the cut interface, t_S = n_S x n_k
+function get_tangent_vector(trian::CutFaceBoundaryTriangulation{Di}) where {Di}
+  @notimplementedif Di != 1
+  n_S = get_normal_vector(trian)
+  n_k = get_ghost_normal_vector(trian)
+  return Operation(cross)(n_S,n_k)
+end
+
+# Conormal vectors, m_k = t_S x n_∂Ω
+function get_conormal_vector(trian::CutFaceBoundaryTriangulation{Di}) where {Di}
+  n_∂Ω = get_subfacet_normal_vector(trian)
+  isign = get_interface_sign(trian)
+  if Di == 0 # 2D
+    cross2D(n) = VectorValue(n[2],-n[1])
+    m_k = Operation(cross2D)(n_∂Ω)
+  elseif Di == 1 # 3D
+    t_S = get_edge_tangents(trian)
+    m_k = Operation(cross)(t_S,n_∂Ω) # m_k = t_S x n_∂Ω (eq 6.26)
+  else
+    @notimplemented
+  end
+  return m_k * isign
+end
+
+# CutFaceSkeletonTriangulation & CutFaceBoundaryTriangulationView
+const CutFaceBoundaryTriangulationView{Di,Df,Dp} = TriangulationView{Di,Dp,CutFaceBoundaryTriangulation{Di,Df,Dp}}
+const CutFaceSkeletonTriangulation{Di,Df,Dp} = SkeletonTriangulation{Di,Dp,<:Union{
+  CutFaceBoundaryTriangulation{Di,Df,Dp},
+  CutFaceBoundaryTriangulationView{Di,Df,Dp}
+  }
+}
+
+function SkeletonTriangulation(face_trian::SubFacetTriangulation)
+  bgmodel = get_background_model(face_trian)
+  face_model = get_active_model(face_trian)
+
+  ghost_mask = get_ghost_mask(face_trian,face_model)
+  face_skeleton = SkeletonTriangulation(face_model,ghost_mask)
+  cell_skeleton = CompositeTriangulation(face_trian,face_skeleton)
+  ghost_skeleton = generate_ghost_trian(cell_skeleton,bgmodel)
+
+  ctrian_plus = CompositeTriangulation(face_trian,face_skeleton.plus)
+  ctrian_minus = CompositeTriangulation(face_trian,face_skeleton.minus)
+  isign_plus = get_interface_sign(ctrian_plus,face_trian,ghost_skeleton.plus)
+  isign_minus = get_interface_sign(ctrian_plus,face_trian,ghost_skeleton.minus)
+
+  plus = CutFaceBoundaryTriangulation(
+    face_model,face_trian,ctrian_plus,
+    face_skeleton.plus,ghost_skeleton.plus,isign_plus
+  )
+  minus = CutFaceBoundaryTriangulation(
+    face_model,face_trian,ctrian_minus,
+    face_skeleton.minus,ghost_skeleton.minus,isign_minus
+  )
+  return SkeletonTriangulation(plus,minus)
+end
+
+for func in (:get_subfacet_normal_vector,:get_ghost_normal_vector,:get_conormal_vector)
+  @eval begin
+    function $func(trian::CutFaceSkeletonTriangulation)
+      plus  = GenericCellField(CellData.get_data($func(trian.plus)),trian,ReferenceDomain())
+      minus = GenericCellField(CellData.get_data($func(trian.minus)),trian,ReferenceDomain())
+      return SkeletonPair(plus,minus)
+    end
+  end
+end
+
+for func in (:get_normal_vector,:get_tangent_vector)
+  @eval begin
+    function $func(trian::CutFaceSkeletonTriangulation)
+      return GenericCellField(CellData.get_data($func(trian.plus)),trian,ReferenceDomain())
+    end
+  end
+end
+
+for func in (:get_tangent_vector,:get_subfacet_normal_vector,:get_ghost_normal_vector,:get_conormal_vector)
+  @eval begin
+    function $func(trian::CutFaceBoundaryTriangulationView)
+      data = CellData.get_data($func(trian.parent))
+      restricted_data = restrict(data,trian.cell_to_parent_cell)
+      return GenericCellField(restricted_data,trian,ReferenceDomain())
+    end
+  end
+end
+
+# Distributed
+# Until we merge, we need changes in
+#   - GridapDistributed#master
+#   - GridapEmbedded#distributed
+
+# function GridapDistributed.remove_ghost_cells(
+#   trian::Union{<:CutFaceBoundaryTriangulation,<:CutFaceSkeletonTriangulation},gids
+# )
+#   model = get_background_model(trian)
+#   Dm    = num_cell_dims(model)
+#   glue  = get_glue(trian,Val(Dm))
+#   GridapDistributed.remove_ghost_cells(glue,trian,gids)
+# end
+# 
+# for func in (:get_subfacet_normal_vector,:get_ghost_normal_vector,:get_conormal_vector,:get_tangent_vector)
+#   @eval begin
+#     function $func(a::DistributedTriangulation)
+#       fields = map($func,local_views(a))
+#       DistributedCellField(fields,a)
+#     end
+#   end
+# end
+
+############################################################################################
+# This will go to Gridap
+
+function Arrays.evaluate!(cache,k::Operation,a::SkeletonPair{<:CellField})
+  plus = k(a.plus)
+  minus = k(a.minus)
+  SkeletonPair(plus,minus)
+end
+
+function Arrays.evaluate!(cache,k::Operation,a::SkeletonPair{<:CellField},b::SkeletonPair{<:CellField})
+  plus = k(a.plus,b.plus)
+  minus = k(a.minus,b.minus)
+  SkeletonPair(plus,minus)
+end
+
+import Gridap.TensorValues: inner, outer
+import LinearAlgebra: dot
+import Base: abs, *, +, -, /
+
+for op in (:/,)
+  @eval begin
+    ($op)(a::CellField,b::SkeletonPair{<:CellField}) = Operation($op)(a,b)
+    ($op)(a::SkeletonPair{<:CellField},b::CellField) = Operation($op)(a,b)
+  end
+end
+
+for op in (:outer,:*,:dot,:/)
+  @eval begin
+    ($op)(a::SkeletonPair{<:CellField},b::SkeletonPair{<:CellField}) = Operation($op)(a,b)
+  end
+end
+
+function CellData.change_domain(a::SkeletonPair, ::ReferenceDomain, ::PhysicalDomain)
+  plus = change_domain(a.plus,ReferenceDomain(),PhysicalDomain())
+  minus = change_domain(a.minus,ReferenceDomain(),PhysicalDomain())
+  return SkeletonPair(plus,minus)
+end

--- a/src/Interfaces/CutFaceBoundaryTriangulations.jl
+++ b/src/Interfaces/CutFaceBoundaryTriangulations.jl
@@ -393,29 +393,6 @@ for func in (:get_tangent_vector,:get_subfacet_normal_vector,:get_ghost_normal_v
   end
 end
 
-# Distributed
-# Until we merge, we need changes in
-#   - GridapDistributed#master
-#   - GridapEmbedded#distributed
-
-# function GridapDistributed.remove_ghost_cells(
-#   trian::Union{<:CutFaceBoundaryTriangulation,<:CutFaceSkeletonTriangulation},gids
-# )
-#   model = get_background_model(trian)
-#   Dm    = num_cell_dims(model)
-#   glue  = get_glue(trian,Val(Dm))
-#   GridapDistributed.remove_ghost_cells(glue,trian,gids)
-# end
-# 
-# for func in (:get_subfacet_normal_vector,:get_ghost_normal_vector,:get_conormal_vector,:get_tangent_vector)
-#   @eval begin
-#     function $func(a::DistributedTriangulation)
-#       fields = map($func,local_views(a))
-#       DistributedCellField(fields,a)
-#     end
-#   end
-# end
-
 ############################################################################################
 # This will go to Gridap
 

--- a/src/Interfaces/Cutters.jl
+++ b/src/Interfaces/Cutters.jl
@@ -1,17 +1,60 @@
+
+"""
+    abstract type Cutter <: GridapType end
+
+Abstract type for all mesh cutters. Has to be paired with a [`CSG.Geometry`](@ref) to 
+cut the background mesh.
+
+## Methods
+
+- [`cut(cutter::Cutter,background,geom)`](@ref)
+- [`cut_facets(cutter::Cutter,background,geom)`](@ref)
+- [`compute_bgcell_to_inoutcut(cutter::Cutter,background,geom)`](@ref)
+- [`compute_bgfacet_to_inoutcut(cutter::Cutter,background,geom)`](@ref)
+
+Generally `cut` and `cut_facets` dispatch based on the geometry provided, so it is 
+generally more convennient to call the following methods instead:
+
+- [`cut(background,geom)`](@ref)
+- [`cut_facets(background,geom)`](@ref)
+
+"""
 abstract type Cutter <: GridapType end
 
+"""
+    cut(cutter::Cutter,background,geom)
+
+Cut the background mesh with the provided cutter and geometry, returnning the cut cells.
+The cut cells are returned as an [`EmbeddedDiscretization`](@ref) object.
+"""
 function cut(cutter::Cutter,background,geom)
   @abstractmethod
 end
 
+"""
+    compute_bgcell_to_inoutcut(cutter::Cutter,background,geom)
+
+Returns an array of IN/OUT/CUT states for each cell in the background mesh.
+"""
 function compute_bgcell_to_inoutcut(cutter::Cutter,background,geom)
   @abstractmethod
 end
 
+"""
+    cut_facets(cutter::Cutter,background,geom)
+
+Cut the background mesh with the provided cutter and geometry, returning the cut facets.
+The cut facets are returned as an [`EmbeddedFacetDiscretization`](@ref) object.
+"""
 function cut_facets(cutter::Cutter,background,geom)
   @abstractmethod
 end
 
+"""
+    compute_bgfacet_to_inoutcut(cutter::Cutter,background,geom)
+
+Returns an array of IN/OUT/CUT states for each facet in the background mesh.
+"""
 function compute_bgfacet_to_inoutcut(cutter::Cutter,background,geom)
   @abstractmethod
 end

--- a/src/Interfaces/EmbeddedDiscretizations.jl
+++ b/src/Interfaces/EmbeddedDiscretizations.jl
@@ -1,6 +1,42 @@
-
+"""
+    abstract type EmbeddedDiscretization <: GridapType end
+"""
 abstract type AbstractEmbeddedDiscretization <: GridapType end
 
+"""
+    struct EmbeddedDiscretization{Dc,T} <: AbstractEmbeddedDiscretization
+      bgmodel::DiscreteModel
+      ls_to_bgcell_to_inoutcut::Vector{Vector{Int8}}
+      subcells::SubCellData{Dc,Dc,T}
+      ls_to_subcell_to_inout::Vector{Vector{Int8}}
+      subfacets::SubFacetData{Dc,T}
+      ls_to_subfacet_to_inout::Vector{Vector{Int8}}
+      oid_to_ls::Dict{UInt,Int}
+      geo::CSG.Geometry
+    end
+
+This structure contains all the required information to build integration `Triangulation`s 
+for a cut model.
+
+## Constructors
+
+    EmbeddedDiscretization(cutter::Cutter,background,geom)
+
+## Properties
+
+- `bgmodel::DiscreteModel`: the background mesh
+- `geo::CSG.Geometry`: the geometry used to cut the background mesh
+- `subcells::SubCellData`: collection of cut subcells, attached to the background mesh
+- `subfacets::SubFacetData`: collection of cut facets, attached to the background mesh
+- `ls_to_X_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each cell/facet 
+   in the background mesh, for each node in the geometry tree.
+
+## Methods
+
+- [`Triangulation(cut::EmbeddedDiscretization,in_or_out)`](@ref)
+- [`EmbeddedBoundary(cut::EmbeddedDiscretization)`](@ref)
+
+"""
 struct EmbeddedDiscretization{Dc,T} <: AbstractEmbeddedDiscretization
   bgmodel::DiscreteModel
   ls_to_bgcell_to_inoutcut::Vector{Vector{Int8}}
@@ -224,6 +260,9 @@ function Triangulation(cut::EmbeddedDiscretization)
   Triangulation(cut,PHYSICAL_IN,cut.geo)
 end
 
+"""
+    Triangulation(cut::EmbeddedDiscretization[,in_or_out=PHYSICAL_IN])
+"""
 function Triangulation(cut::EmbeddedDiscretization,in_or_out)
   Triangulation(cut,in_or_out,cut.geo)
 end
@@ -355,6 +394,9 @@ function _compute_inout_complementary(inout_1)
   end
 end
 
+"""
+    EmbeddedBoundary(cut::EmbeddedDiscretization)
+"""
 function EmbeddedBoundary(cut::EmbeddedDiscretization)
   EmbeddedBoundary(cut,cut.geo)
 end

--- a/src/Interfaces/EmbeddedDiscretizations.jl
+++ b/src/Interfaces/EmbeddedDiscretizations.jl
@@ -1,26 +1,17 @@
 """
-    abstract type EmbeddedDiscretization <: GridapType end
+    abstract type EmbeddedDiscretization <: GridapType
 """
 abstract type AbstractEmbeddedDiscretization <: GridapType end
 
 """
     struct EmbeddedDiscretization{Dc,T} <: AbstractEmbeddedDiscretization
-      bgmodel::DiscreteModel
-      ls_to_bgcell_to_inoutcut::Vector{Vector{Int8}}
-      subcells::SubCellData{Dc,Dc,T}
-      ls_to_subcell_to_inout::Vector{Vector{Int8}}
-      subfacets::SubFacetData{Dc,T}
-      ls_to_subfacet_to_inout::Vector{Vector{Int8}}
-      oid_to_ls::Dict{UInt,Int}
-      geo::CSG.Geometry
-    end
 
 This structure contains all the required information to build integration `Triangulation`s 
 for a cut model.
 
 ## Constructors
 
-    EmbeddedDiscretization(cutter::Cutter,background,geom)
+    cut(cutter::Cutter,background,geom)
 
 ## Properties
 
@@ -28,13 +19,18 @@ for a cut model.
 - `geo::CSG.Geometry`: the geometry used to cut the background mesh
 - `subcells::SubCellData`: collection of cut subcells, attached to the background mesh
 - `subfacets::SubFacetData`: collection of cut facets, attached to the background mesh
-- `ls_to_X_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each cell/facet 
+- `ls_to_bgcell_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each cell 
    in the background mesh, for each node in the geometry tree.
+- `ls_to_subcell_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each subcell 
+   in the cut part of the mesh, for each node in the geometry tree.
+- `ls_to_subfacet_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each subfacet 
+   in the cut part of the mesh, for each node in the geometry tree.
 
 ## Methods
 
 - [`Triangulation(cut::EmbeddedDiscretization,in_or_out)`](@ref)
 - [`EmbeddedBoundary(cut::EmbeddedDiscretization)`](@ref)
+- [`GhostSkeleton(cut::EmbeddedDiscretization)`](@ref)
 
 """
 struct EmbeddedDiscretization{Dc,T} <: AbstractEmbeddedDiscretization
@@ -456,6 +452,9 @@ function EmbeddedBoundary(cut::EmbeddedDiscretization,geo1::CSG.Geometry,geo2::C
 
 end
 
+"""
+    GhostSkeleton(cut::EmbeddedDiscretization[,in_or_out=ACTIVE_IN])
+"""
 function GhostSkeleton(cut::EmbeddedDiscretization)
   GhostSkeleton(cut,ACTIVE_IN)
 end

--- a/src/Interfaces/EmbeddedDiscretizations.jl
+++ b/src/Interfaces/EmbeddedDiscretizations.jl
@@ -258,6 +258,15 @@ end
 
 """
     Triangulation(cut::EmbeddedDiscretization[,in_or_out=PHYSICAL_IN])
+
+Creates a triangulation containing the cell and subcells of the embedded domain selected by 
+`in_or_out`.
+
+- If only background cells are selected, the result will be a regular Gridap triangulation.
+- If only subcells are selected, the result will be a [`SubCellTriangulation`](@ref).
+- If both background cells and subcells are selected, the result will be an `AppendedTriangulation`, 
+  containing a [`SubCellTriangulation`](@ref) and a regular Gridap triangulation.
+
 """
 function Triangulation(cut::EmbeddedDiscretization,in_or_out)
   Triangulation(cut,in_or_out,cut.geo)
@@ -392,6 +401,9 @@ end
 
 """
     EmbeddedBoundary(cut::EmbeddedDiscretization)
+
+Creates a triangulation containing the cut facets of the embedded domain boundary.
+The result is a [`SubFacetTriangulation`](@ref).
 """
 function EmbeddedBoundary(cut::EmbeddedDiscretization)
   EmbeddedBoundary(cut,cut.geo)
@@ -419,7 +431,6 @@ function EmbeddedBoundary(cut::EmbeddedDiscretization,geo::CSG.Geometry)
   neworientation = orientation[newsubfacets]
   fst = SubFacetData(cut.subfacets,newsubfacets,neworientation)
   SubFacetTriangulation(fst,cut.bgmodel)
-
 end
 
 function EmbeddedBoundary(cut::EmbeddedDiscretization,name1::String,name2::String)
@@ -449,11 +460,15 @@ function EmbeddedBoundary(cut::EmbeddedDiscretization,geo1::CSG.Geometry,geo2::C
   neworientation = orientation[newsubfacets]
   fst = SubFacetData(cut.subfacets,newsubfacets,neworientation)
   SubFacetTriangulation(fst,cut.bgmodel)
-
 end
 
 """
     GhostSkeleton(cut::EmbeddedDiscretization[,in_or_out=ACTIVE_IN])
+
+Creates a triangulation containing the ghost facets. Ghosts facets are defined as the facets 
+of the **background mesh** that are adjacent to at least one `CUT` background cell.
+
+Mostly used for CUT-FEM stabilisation. 
 """
 function GhostSkeleton(cut::EmbeddedDiscretization)
   GhostSkeleton(cut,ACTIVE_IN)

--- a/src/Interfaces/EmbeddedFacetDiscretizations.jl
+++ b/src/Interfaces/EmbeddedFacetDiscretizations.jl
@@ -1,4 +1,30 @@
 
+"""
+    struct EmbeddedFacetDiscretization{Dc,Dp,T} <: AbstractEmbeddedDiscretization
+
+This structure contains all the required information to build integration `Triangulations` 
+for a cut model boundary.
+
+## Constructors
+
+    cut_facets(cutter::Cutter,background,geom)
+
+## Properties
+
+- `bgmodel::DiscreteModel`: the background mesh
+- `geo::CSG.Geometry`: the geometry used to cut the background mesh
+- `subfacets::SubFacetData`: collection of cut facets, attached to the background mesh
+- `ls_to_facet_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each facet 
+   in the background mesh, for each node in the geometry tree.
+- `ls_to_subfacet_to_inoutcut::Vector{Vector{Int8}}`: list of IN/OUT/CUT states for each subfacet 
+   in the cut part of the mesh, for each node in the geometry tree.
+
+## Methods
+
+- [`BoundaryTriangulation(cut::EmbeddedFacetDiscretization,in_or_out)`](@ref)
+- [`SkeletonTriangulation(cut::EmbeddedFacetDiscretization,in_or_out)`](@ref)
+
+"""
 struct EmbeddedFacetDiscretization{Dc,Dp,T} <: AbstractEmbeddedDiscretization
   bgmodel::DiscreteModel{Dp,Dp}
   ls_to_facet_to_inoutcut::Vector{Vector{Int8}}
@@ -20,6 +46,9 @@ function SkeletonTriangulation(cut::EmbeddedFacetDiscretization)
   SkeletonTriangulation(cut,PHYSICAL_IN)
 end
 
+"""
+    SkeletonTriangulation(cut::EmbeddedFacetDiscretization[, in_or_out=PHYSICAL_IN])
+"""
 function SkeletonTriangulation(
   cut::EmbeddedFacetDiscretization,
   in_or_out)
@@ -75,6 +104,9 @@ function BoundaryTriangulation(
   BoundaryTriangulation(cut,PHYSICAL_IN;tags=tags)
 end
 
+"""
+    BoundaryTriangulation(cut::EmbeddedFacetDiscretization[, in_or_out=PHYSICAL_IN; tags=nothing])
+"""
 function BoundaryTriangulation(
   cut::EmbeddedFacetDiscretization,
   in_or_out;
@@ -232,10 +264,10 @@ in this triangulation is part of a background facet that has been cut by the geo
 This differs from the the `SubFacetTriangulation` in that the facets in the `SubFacetTriangulation` 
 are not cut background facets, but rather subfacets on the interior of a background cell.
 
-They result from calling `Boundary` or `Skeleton` on an `EmbeddedFacetDiscretization` object, 
-for instance: 
+They result from calling `Boundary` or `Skeleton` on an `EmbeddedFacetDiscretization` object.
 
-    BoundaryTriangulation(cut::EmbeddedFacetDiscretization,in_or_out,geo;tags=nothing)
+    BoundaryTriangulation(cut::EmbeddedFacetDiscretization,in_or_out;tags=nothing)
+    SkeletonTriangulation(cut::EmbeddedFacetDiscretization,in_or_out)
 
 """
 struct SubFacetBoundaryTriangulation{Dc,Dp,T} <: Triangulation{Dc,Dp}

--- a/src/Interfaces/EmbeddedFacetDiscretizations.jl
+++ b/src/Interfaces/EmbeddedFacetDiscretizations.jl
@@ -223,6 +223,21 @@ function compute_subfacet_to_inout(cut::EmbeddedFacetDiscretization,geo::CSG.Geo
   compute_inoutcut(newtree)
 end
 
+"""
+    struct SubFacetBoundaryTriangulation{Dc,Dp,T} <: Triangulation{Dc,Dp}
+
+Triangulation of cut facets from the background mesh, i.e each of the facets 
+in this triangulation is part of a background facet that has been cut by the geometry.
+
+This differs from the the `SubFacetTriangulation` in that the facets in the `SubFacetTriangulation` 
+are not cut background facets, but rather subfacets on the interior of a background cell.
+
+They result from calling `Boundary` or `Skeleton` on an `EmbeddedFacetDiscretization` object, 
+for instance: 
+
+    BoundaryTriangulation(cut::EmbeddedFacetDiscretization,in_or_out,geo;tags=nothing)
+
+"""
 struct SubFacetBoundaryTriangulation{Dc,Dp,T} <: Triangulation{Dc,Dp}
   facets::BoundaryTriangulation{Dc,Dp}
   subfacets::SubCellData{Dc,Dp,T}

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -1,5 +1,6 @@
 module Interfaces
 
+using Gridap
 using Gridap.Helpers
 using Gridap.Arrays
 using Gridap.Fields
@@ -21,12 +22,14 @@ import Gridap.Geometry: get_reffes
 import Gridap.Geometry: get_cell_type
 import Gridap.Geometry: get_background_model
 import Gridap.Geometry: get_active_model
+import Gridap.Geometry: compute_active_model
 import Gridap.Geometry: get_glue
 import Gridap.Geometry: get_grid
 import Gridap.Geometry: FaceToFaceGlue
 import Gridap.Geometry: get_facet_normal
 import Gridap.Geometry: move_contributions
 using Gridap.Geometry: GenericTriangulation
+using Gridap.Geometry: CompositeTriangulation
 
 using GridapEmbedded.CSG
 

--- a/src/Interfaces/Interfaces.jl
+++ b/src/Interfaces/Interfaces.jl
@@ -1,5 +1,7 @@
 module Interfaces
 
+using FillArrays
+
 using Gridap
 using Gridap.Helpers
 using Gridap.Arrays
@@ -28,8 +30,15 @@ import Gridap.Geometry: get_grid
 import Gridap.Geometry: FaceToFaceGlue
 import Gridap.Geometry: get_facet_normal
 import Gridap.Geometry: move_contributions
+import Gridap.Geometry: is_change_possible
 using Gridap.Geometry: GenericTriangulation
 using Gridap.Geometry: CompositeTriangulation
+using Gridap.Geometry: TriangulationView
+using Gridap.Geometry: restrict
+
+import Gridap.CellData: get_normal_vector
+import Gridap.CellData: get_tangent_vector
+import Gridap.Geometry: get_facet_normal
 
 using GridapEmbedded.CSG
 
@@ -86,6 +95,8 @@ include("SubFacetTriangulations.jl")
 include("EmbeddedDiscretizations.jl")
 
 include("EmbeddedFacetDiscretizations.jl")
+
+include("CutFaceBoundaryTriangulations.jl")
 
 include("Cutters.jl")
 

--- a/src/Interfaces/SubCellTriangulations.jl
+++ b/src/Interfaces/SubCellTriangulations.jl
@@ -18,6 +18,11 @@ end
 
 # Implementation of Triangulation interface
 
+"""
+    struct SubCellTriangulation{Dc,Dp} <: Triangulation{Dc,Dp}
+
+A triangulation for subcells. 
+"""
 struct SubCellTriangulation{Dc,Dp,T,A} <: Triangulation{Dc,Dp}
   subcells::SubCellData{Dc,Dp,T}
   bgmodel::A

--- a/src/Interfaces/SubFacetTriangulations.jl
+++ b/src/Interfaces/SubFacetTriangulations.jl
@@ -22,6 +22,11 @@ end
 
 # Implementation of the Gridap.Triangulation interface
 
+"""
+    struct SubFacetTriangulation{Dc,Dp,T,A} <: Triangulation{Dc,Dp}
+
+A triangulation for subfacets.
+"""
 struct SubFacetTriangulation{Dc,Dp,T,A} <: Triangulation{Dc,Dp}
   subfacets::SubFacetData{Dp,T}
   bgmodel::A

--- a/src/LevelSetCutters/AnalyticalGeometries.jl
+++ b/src/LevelSetCutters/AnalyticalGeometries.jl
@@ -1,4 +1,33 @@
 
+"""
+    struct AnalyticalGeometry <: CSG.Geometry
+      tree::Node
+    end
+
+A structure to represent analytical geometries, used to cut background meshes.
+
+## Constructor
+
+    AnalyticalGeometry(f::Function;name=string(nameof(f)))
+
+where `f: Ω -> R ` is a function that, similiarly to a level set function, is negative inside the
+geometry and positive outside.
+
+## Predefined geometries
+
+    doughnut(R,r;x0=zero(Point{3,typeof(R)}),name="doughnut")
+    popcorn(r0=0.6, σ=0.2, A=2, x0=zero(Point{3,typeof(r0)}), name="popcorn")
+    sphere(R;x0=zero(Point{3,eltype(R)}),name="sphere")
+    disk(R;x0=zero(Point{2,eltype(R)}),name="disk")
+    cylinder(R;x0=zero(Point{3,eltype(R)}),v=VectorValue(1,0,0),name="cylinder")
+    plane(x0=Point(0,0,0),v=VectorValue(1,0,0),name="plane")
+    square(L=1,x0=Point(0,0),name="square",edges=["edge_i" for i in 1:4])
+    quadrilateral(x0=Point(0,0),d1=VectorValue(1,0),d2=VectorValue(0,1),name="quadrilateral")
+    cube(L=1,x0=Point(0,0,0),name="cube")
+    tube(R,L;x0=zero(Point{3,typeof(R)}),v=VectorValue(1,0,0),name="tube")
+    olympic_rings(R,r,name="olympic_rings")
+
+"""
 struct AnalyticalGeometry <: CSG.Geometry
   tree::Node
 end
@@ -14,8 +43,8 @@ struct BoundingBox{D,T}
   pmax::Point{D,T}
 end
 
-function AnalyticalGeometry(f::Function)
-  tree = Leaf((f,string(nameof(f)),nothing))
+function AnalyticalGeometry(f::Function;name=string(nameof(f)))
+  tree = Leaf((f,name,nothing))
   AnalyticalGeometry(tree)
 end
 

--- a/src/LevelSetCutters/DifferentiableTriangulations.jl
+++ b/src/LevelSetCutters/DifferentiableTriangulations.jl
@@ -1,0 +1,540 @@
+
+
+"""
+    mutable struct DifferentiableTriangulation{Dc,Dp} <: Triangulation{Dc,Dp}
+
+A DifferentiableTriangulation is a wrapper around an embedded triangulation
+(i.e SubCellTriangulation or SubFacetTriangulation) implementing all the necessary
+methods to compute derivatives w.r.t. deformations of the embedded mesh.
+
+To do so, it propagates dual numbers into the geometric maps mapping cut subcells/subfacets
+to the background mesh.
+
+## Constructor: 
+
+    DifferentiableTriangulation(trian::Triangulation,fe_space::FESpace)
+
+where `trian` must be an embedded triangulation and `fe_space` is the `FESpace` where 
+the level-set function lives.
+
+"""
+mutable struct DifferentiableTriangulation{Dc,Dp,A,B} <: Triangulation{Dc,Dp}
+  trian :: A
+  fe_space :: B
+  cell_values
+  caches
+  function DifferentiableTriangulation(
+    trian :: Triangulation{Dc,Dp},
+    fe_space :: FESpace,
+    cell_values,caches
+  ) where {Dc,Dp}
+    A = typeof(trian)
+    B = typeof(fe_space)
+    new{Dc,Dp,A,B}(trian,fe_space,cell_values,caches)
+  end
+end
+
+# Constructors
+
+DifferentiableTriangulation(trian::Triangulation,fe_space) = trian
+
+function DifferentiableTriangulation(
+  trian::Union{<:SubCellTriangulation,<:SubFacetTriangulation},
+  fe_space::FESpace
+)
+  caches = precompute_autodiff_caches(trian)
+  return DifferentiableTriangulation(trian,fe_space,nothing,caches)
+end
+
+# Update cell values
+
+(t::DifferentiableTriangulation)(φh) = update_trian!(t,get_fe_space(φh),φh)
+
+update_trian!(trian::Triangulation,U,φh) = trian
+
+function update_trian!(trian::DifferentiableTriangulation,space::FESpace,φh)
+  (trian.fe_space !== space) && return trian
+  trian.cell_values = extract_dualized_cell_values(trian.trian,φh)
+  return trian
+end
+
+function update_trian!(trian::DifferentiableTriangulation,::FESpace,::Nothing)
+  trian.cell_values = nothing
+  return trian
+end
+
+# Autodiff
+
+function FESpaces._change_argument(
+  op,f,trian::DifferentiableTriangulation,uh
+)
+  U = get_fe_space(uh)
+  function g(cell_u)
+    cf = CellField(U,cell_u)
+    update_trian!(trian,U,cf)
+    cell_grad = f(cf)
+    update_trian!(trian,U,nothing) # TODO: experimental
+    get_contribution(cell_grad,trian)
+  end
+  g
+end
+
+function FESpaces._compute_cell_ids(uh,ttrian::DifferentiableTriangulation)
+  FESpaces._compute_cell_ids(uh,ttrian.trian)
+end
+
+function Geometry.get_background_model(t::DifferentiableTriangulation)
+  get_background_model(t.trian)
+end
+
+function Geometry.get_grid(t::DifferentiableTriangulation)
+  get_grid(t.trian)
+end
+
+function Geometry.get_cell_reffe(t::DifferentiableTriangulation)
+  get_cell_reffe(t.trian)
+end
+
+# TODO: Do we ever need to dualize the cell points?
+# I think its not necessary, since all the dual numbers are propagated through the cellmaps...
+# Also: The current version dualizes only the phys points...
+# If we want to indeed dualize this, we should probably also dualize the ref points
+# in the case where ttrian.trian is a SubCellTriangulation (but not in the case of a SubFacetTriangulation)
+# Anyway, I don't think this matters for now...
+function CellData.get_cell_points(ttrian::DifferentiableTriangulation)
+  pts = get_cell_points(ttrian.trian)
+  cell_ref_point = pts.cell_ref_point
+  if isnothing(ttrian.cell_values) || isempty(ttrian.cell_values)
+    cell_phys_point = pts.cell_phys_point
+  else
+    c = ttrian.caches
+    cell_phys_point = lazy_map(
+      DualizeCoordsMap(),c.face_to_coords,c.face_to_bgcoords,
+      ttrian.cell_values,c.face_to_edges,c.face_to_edge_lists
+    )
+  end
+  return CellPoint(cell_ref_point, cell_phys_point, ttrian, DomainStyle(pts))
+end
+
+function Geometry.get_cell_map(ttrian::DifferentiableTriangulation)
+  if isnothing(ttrian.cell_values) || isempty(ttrian.cell_values)
+    return get_cell_map(ttrian.trian)
+  end
+  c = ttrian.caches
+  cell_values = ttrian.cell_values
+  cell_to_coords = lazy_map(
+    DualizeCoordsMap(),c.face_to_coords,c.face_to_bgcoords,
+    cell_values,c.face_to_edges,c.face_to_edge_lists
+  )
+  cell_reffe = get_cell_reffe(ttrian)
+  cell_map = compute_cell_maps(cell_to_coords,cell_reffe)
+  return cell_map
+end
+
+function face_normal(face_coords::Vector{<:Point},orientation::Int8)
+  n = face_normal(face_coords)
+  return n*orientation
+end
+function face_normal(face_coords::Vector{<:Point{2}})
+  p1, p2 = face_coords[1:2]
+  LevelSetCutters._normal_vector(p2-p1)
+end
+function face_normal(face_coords::Vector{<:Point{3}})
+  p1, p2, p3 = face_coords[1:3]
+  LevelSetCutters._normal_vector(p2-p1,p3-p1)
+end
+
+function Geometry.get_facet_normal(
+  ttrian::DifferentiableTriangulation{Dc,Dp,<:SubFacetTriangulation}
+) where {Dc,Dp}
+  if isnothing(ttrian.cell_values) || isempty(ttrian.cell_values)
+    return get_facet_normal(ttrian.trian)
+  end
+  c = ttrian.caches
+  cell_values = ttrian.cell_values
+  cell_to_coords = lazy_map(
+    DualizeCoordsMap(),c.face_to_coords,c.face_to_bgcoords,
+    cell_values,c.face_to_edges,c.face_to_edge_lists
+  )
+  facet_normals = lazy_map(face_normal,cell_to_coords,c.orientations)
+  return lazy_map(constant_field,facet_normals)
+end
+
+function Geometry.get_glue(ttrian::DifferentiableTriangulation,val::Val{D}) where {D}
+  glue = get_glue(ttrian.trian,val)
+  if isnothing(glue) || isnothing(ttrian.cell_values) || isempty(ttrian.cell_values)
+    return glue
+  end
+
+  # New reference maps
+  c = ttrian.caches
+  cell_values = ttrian.cell_values
+  cell_to_rcoords = lazy_map(
+    DualizeCoordsMap(),c.face_to_rcoords,c.face_to_bgrcoords,
+    cell_values,c.face_to_edges,c.face_to_edge_lists
+  )
+  cell_reffe = get_cell_reffe(ttrian)
+  ref_cell_map = compute_cell_maps(cell_to_rcoords,cell_reffe)
+
+  return FaceToFaceGlue(
+    glue.tface_to_mface,
+    ref_cell_map,
+    glue.mface_to_tface,
+  )
+end
+
+function Geometry.is_change_possible(
+  strian::A,ttrian::DifferentiableTriangulation{Dc,Dp,A}
+) where {Dc,Dp,A <: Union{SubCellTriangulation,SubFacetTriangulation}}
+  return strian === ttrian.trian
+end
+
+function Geometry.best_target(
+  strian::A,ttrian::DifferentiableTriangulation{Dc,Dp,A}
+) where {Dc,Dp,A <: Union{SubCellTriangulation,SubFacetTriangulation}}
+  return ttrian
+end
+
+for tdomain in (:ReferenceDomain,:PhysicalDomain)
+  for sdomain in (:ReferenceDomain,:PhysicalDomain)
+    @eval begin
+      function CellData.change_domain(
+        a::CellField,strian::A,::$sdomain,ttrian::DifferentiableTriangulation{Dc,Dp,A},::$tdomain
+      ) where {Dc,Dp,A <: Union{SubCellTriangulation,SubFacetTriangulation}}
+        @assert is_change_possible(strian,ttrian)
+        b = change_domain(a,$(tdomain)())
+        return CellData.similar_cell_field(a,CellData.get_data(b),ttrian,$(tdomain)())
+      end
+    end
+  end
+end
+
+function FESpaces.get_cell_fe_data(fun,f,ttrian::DifferentiableTriangulation)
+  FESpaces.get_cell_fe_data(fun,f,ttrian.trian)
+end
+
+function compute_cell_maps(cell_coords,cell_reffes)
+  cell_shapefuns = lazy_map(get_shapefuns,cell_reffes)
+  default_cell_map = lazy_map(linear_combination,cell_coords,cell_shapefuns)
+  default_cell_grad = lazy_map(∇,default_cell_map)
+  cell_poly = lazy_map(get_polytope,cell_reffes)
+  cell_q0 = lazy_map(p->zero(first(get_vertex_coordinates(p))),cell_poly)
+  origins = lazy_map(evaluate,default_cell_map,cell_q0)
+  gradients = lazy_map(evaluate,default_cell_grad,cell_q0)
+  cell_map = lazy_map(Gridap.Fields.affine_map,gradients,origins)
+  return cell_map
+end
+
+# DualizeCoordsMap
+
+struct DualizeCoordsMap <: Map end
+
+function Arrays.return_cache(
+  k::DualizeCoordsMap,
+  coords::Vector{<:Point{Dp,Tp}},
+  bg_coords::Vector{<:Point{Dp,Tp}},
+  values::Vector{Tv},
+  edges::Vector{Int8},
+  edge_list::Vector{Vector{Int8}}
+) where {Dp,Tp,Tv}
+  T = Point{Dp,Tv}
+  return CachedArray(zeros(T, length(coords)))
+end
+
+function Arrays.evaluate!(
+  cache,
+  k::DualizeCoordsMap,
+  coords::Vector{<:Point{Dp,Tp}},
+  bg_coords::Vector{<:Point{Dp,Tp}},
+  values::Vector{Tv},
+  edges::Vector{Int8},
+  edge_list::Vector{Vector{Int8}}
+) where {Dp,Tp,Tv}
+  setsize!(cache,(length(coords),))
+  new_coords = cache.array
+  for (i,e) in enumerate(edges)
+    if e == -1
+      new_coords[i] = coords[i]
+    else
+      n1, n2 = edge_list[e]
+      q1, q2 = bg_coords[n1], bg_coords[n2]
+      v1, v2 = abs(values[n1]), abs(values[n2])
+      λ = v1/(v1+v2)
+      new_coords[i] = q1 + λ*(q2-q1)
+    end
+  end
+  return new_coords
+end
+
+"""
+    precompute_cut_edge_ids(rcoords,bg_rcoords,edge_list)
+
+Given
+  - `rcoords`: the node ref coordinates of the cut subcell/subfacet,
+  - `bg_rcoords`: the node ref coordinates of the background cell containing it,
+  - `edge_list`: the list of nodes defining each edge of the background cell,
+
+this function returns a vector that for each node of the cut subcell/subfacet contains
+  - `-1` if the node is also a node of the background cell,
+  - the id of the edge containing the node otherwise.
+"""
+function precompute_cut_edge_ids(
+  rcoords::Vector{<:Point{Dp,Tp}},
+  bg_rcoords::Vector{<:Point{Dp,Tp}},
+  edge_list::Vector{<:Vector{<:Integer}}
+) where {Dp,Tp}
+  tol = 10*eps(Tp)
+  edges = Vector{Int8}(undef,length(rcoords))
+  for (i,p) in enumerate(rcoords)
+    if any(q -> norm(q-p) < tol, bg_rcoords)
+      edges[i] = Int8(-1)
+    else
+      e = findfirst(edge -> belongs_to_edge(p,edge,bg_rcoords), edge_list)
+      edges[i] = Int8(e)
+    end
+  end
+  return edges
+end
+
+function get_edge_list(poly::Polytope)
+  ltcell_to_lpoints, simplex = simplexify(poly)
+  simplex_edges = get_faces(simplex,1,0)
+  ltcell_to_edges = map(pts -> map(e -> pts[e], simplex_edges), ltcell_to_lpoints)
+  return collect(Vector{Int8},unique(sort,vcat(ltcell_to_edges...)))
+end
+
+function belongs_to_edge(
+  p::Point{D,T},edge::Vector{<:Integer},bgpts::Vector{Point{D,T}}
+) where {D,T}
+  tol = 10*eps(T)
+  p1, p2 = bgpts[edge]
+  return norm(cross(p-p1,p2-p1)) < tol
+end
+
+function precompute_autodiff_caches(
+  trian::SubCellTriangulation
+)
+  bgmodel = get_background_model(trian)
+  subcells = trian.subcells
+
+  precompute_autodiff_caches(
+    bgmodel,
+    subcells.cell_to_bgcell,
+    subcells.cell_to_points,
+    subcells.point_to_rcoords,
+    subcells.point_to_coords,
+  )
+end
+
+function precompute_autodiff_caches(
+  trian::SubFacetTriangulation
+)
+  bgmodel = get_background_model(trian)
+  subfacets = trian.subfacets
+
+  caches = precompute_autodiff_caches(
+    bgmodel,
+    subfacets.facet_to_bgcell,
+    subfacets.facet_to_points,
+    subfacets.point_to_rcoords,
+    subfacets.point_to_coords,
+  )
+
+  # Precompute orientations
+  orientations = collect(lazy_map(orient,subfacets.facet_to_normal,caches.face_to_coords))
+
+  cache = (; caches..., orientations)
+  return cache
+end
+
+orient(n,fcoords) = round(Int8,dot(n,face_normal(fcoords)))
+Arrays.return_value(::typeof(orient),n,face_coords) = zero(Int8)
+
+function precompute_autodiff_caches(
+  bgmodel,
+  face_to_bgcell,
+  face_to_points,
+  point_to_rcoords,
+  point_to_coords,
+)
+  bg_ctypes = get_cell_type(bgmodel)
+  bgcell_to_polys = expand_cell_data(get_polytopes(bgmodel),bg_ctypes)
+  bgcell_to_coords = get_cell_coordinates(bgmodel)
+  bgcell_to_rcoords = lazy_map(get_vertex_coordinates,bgcell_to_polys)
+
+  face_to_bgcoords = lazy_map(Reindex(bgcell_to_coords),face_to_bgcell)
+  face_to_bgrcoords = lazy_map(Reindex(bgcell_to_rcoords),face_to_bgcell)
+  face_to_rcoords = lazy_map(Broadcasting(Reindex(point_to_rcoords)),face_to_points)
+  face_to_coords = lazy_map(Broadcasting(Reindex(point_to_coords)),face_to_points)
+
+  bgcell_to_edge_lists = lazy_map(get_edge_list,bgcell_to_polys)
+  face_to_edge_lists = lazy_map(Reindex(bgcell_to_edge_lists),face_to_bgcell)
+  face_to_edges = collect(lazy_map(precompute_cut_edge_ids,face_to_rcoords,face_to_bgrcoords,face_to_edge_lists))
+
+  cache = (;
+    face_to_rcoords,
+    face_to_coords,
+    face_to_bgrcoords,
+    face_to_bgcoords,
+    face_to_edges,
+    face_to_edge_lists
+  )
+  return cache
+end
+
+function extract_dualized_cell_values(
+  trian::SubCellTriangulation,
+  φh::CellField,
+)
+  @assert isa(DomainStyle(φh),ReferenceDomain)
+  bgmodel = get_background_model(trian)
+  bgcell_to_values = extract_dualized_cell_values(bgmodel,φh)
+
+  subcells = trian.subcells
+  cell_to_bgcell = subcells.cell_to_bgcell
+  cell_to_values = lazy_map(Reindex(bgcell_to_values),cell_to_bgcell)
+  return cell_to_values
+end
+
+function extract_dualized_cell_values(
+  trian::SubFacetTriangulation,
+  φh::CellField,
+)
+  @assert isa(DomainStyle(φh),ReferenceDomain)
+  bgmodel = get_background_model(trian)
+  bgcell_to_values = extract_dualized_cell_values(bgmodel,φh)
+
+  subfacets = trian.subfacets
+  facet_to_bgcell = subfacets.facet_to_bgcell
+  facet_to_values = lazy_map(Reindex(bgcell_to_values),facet_to_bgcell)
+  return facet_to_values
+end
+
+function extract_dualized_cell_values(
+  bgmodel::DiscreteModel,
+  φh::CellField,
+)
+  @assert isa(DomainStyle(φh),ReferenceDomain)
+  bg_ctypes = get_cell_type(bgmodel)
+  bgcell_to_polys = expand_cell_data(get_polytopes(bgmodel),bg_ctypes)
+  bgcell_to_rcoords = lazy_map(get_vertex_coordinates,bgcell_to_polys)
+  bgcell_to_fields = CellData.get_data(φh)
+  bgcell_to_values = lazy_map(evaluate,bgcell_to_fields,bgcell_to_rcoords)
+  return bgcell_to_values
+end
+
+# AppendedTriangulation
+#
+# When cutting an embedded domain, we will usually end up with an AppendedTriangulation
+# containing
+#   a) a regular triangulation with the IN/OUT cells
+#   b) a SubCell/SubFacetTriangulation with the CUT cells
+# We only need to propagate the dual numbers to the CUT cells, which is what the
+# following implementation does:
+
+const DifferentiableAppendedTriangulation{Dc,Dp,A} = AppendedTriangulation{Dc,Dp,<:DifferentiableTriangulation}
+
+function DifferentiableTriangulation(
+  trian::AppendedTriangulation, fe_space::FESpace
+)
+  a = DifferentiableTriangulation(trian.a,fe_space)
+  b = DifferentiableTriangulation(trian.b,fe_space)
+  return AppendedTriangulation(a,b)
+end
+
+function update_trian!(trian::DifferentiableAppendedTriangulation,U,φh)
+  update_trian!(trian.a,U,φh)
+  update_trian!(trian.b,U,φh)
+  return trian
+end
+
+function FESpaces._change_argument(
+  op,f,trian::DifferentiableAppendedTriangulation,uh
+)
+  U = get_fe_space(uh)
+  function g(cell_u)
+    cf = CellField(U,cell_u)
+    update_trian!(trian,U,cf)
+    cell_grad = f(cf)
+    update_trian!(trian,U,nothing)
+    get_contribution(cell_grad,trian)
+  end
+  g
+end
+
+# TODO: Move to Gridap
+function FESpaces._compute_cell_ids(uh,ttrian::AppendedTriangulation)
+  ids_a = FESpaces._compute_cell_ids(uh,ttrian.a)
+  ids_b = FESpaces._compute_cell_ids(uh,ttrian.b)
+  lazy_append(ids_a,ids_b)
+end
+
+# TriangulationView
+# This is mostly used in distributed, where we remove ghost cells by taking a view 
+# of the local triangulations. 
+
+function DifferentiableTriangulation(
+  trian :: Geometry.TriangulationView,
+  fe_space :: FESpace
+)
+  parent = DifferentiableTriangulation(trian.parent,fe_space)
+  return Geometry.TriangulationView(parent,trian.cell_to_parent_cell)
+end
+
+function update_trian!(trian::Geometry.TriangulationView,U,φh)
+  update_trian!(trian.parent,U,φh)
+  return trian
+end
+
+function FESpaces._change_argument(
+  op,f,trian::Geometry.TriangulationView,uh
+)
+  U = get_fe_space(uh)
+  function g(cell_u)
+    cf = CellField(U,cell_u)
+    update_trian!(trian,U,cf)
+    cell_grad = f(cf)
+    update_trian!(trian,U,nothing)
+    get_contribution(cell_grad,trian)
+  end
+  g
+end
+
+#### DistributedTriangulations
+
+# function DifferentiableTriangulation(trian::DistributedTriangulation,fe_space)
+#   model = get_background_model(trian)
+#   trians = map(DifferentiableTriangulation,local_views(trian),local_views(fe_space))
+#   return DistributedTriangulation(trians,model)
+# end
+# 
+# function FESpaces._change_argument(
+#   op,f,
+#   local_trians::AbstractArray{<:Union{<:DifferentiableTriangulation,<:DifferentiableAppendedTriangulation,<:TriangulationView}},
+#   uh::GridapDistributed.DistributedADTypes
+# )
+#   function dist_cf(uh::DistributedCellField,cfs)
+#     DistributedCellField(cfs,get_triangulation(uh))
+#   end
+#   function dist_cf(uh::DistributedMultiFieldCellField,cfs)
+#     sf_cfs = map(DistributedCellField,
+#       [tuple_of_arrays(map(cf -> Tuple(cf.single_fields),cfs))...],
+#       map(get_triangulation,uh)
+#     )
+#     DistributedMultiFieldCellField(sf_cfs,cfs)
+#   end
+# 
+#   uhs = local_views(uh)
+#   spaces = map(get_fe_space,uhs)
+#   function g(cell_u)
+#     cfs = map(CellField,spaces,cell_u)
+#     cf = dist_cf(uh,cfs)
+#     map(update_trian!,local_trians,spaces,local_views(cf))
+#     cg = f(cf)
+#     map(local_trians,spaces) do Ω, V
+#       update_trian!(Ω,V,nothing)
+#     end
+#     map(get_contribution,local_views(cg),local_trians)
+#   end
+#   g
+# end

--- a/src/LevelSetCutters/DifferentiableTriangulations.jl
+++ b/src/LevelSetCutters/DifferentiableTriangulations.jl
@@ -221,7 +221,7 @@ function compute_cell_maps(cell_coords,cell_reffes)
   cell_q0 = lazy_map(p->zero(first(get_vertex_coordinates(p))),cell_poly)
   origins = lazy_map(evaluate,default_cell_map,cell_q0)
   gradients = lazy_map(evaluate,default_cell_grad,cell_q0)
-  cell_map = lazy_map(Gridap.Fields.affine_map,gradients,origins)
+  cell_map = lazy_map(Fields.affine_map,gradients,origins)
   return cell_map
 end
 

--- a/src/LevelSetCutters/DiscreteGeometries.jl
+++ b/src/LevelSetCutters/DiscreteGeometries.jl
@@ -1,4 +1,16 @@
 
+"""
+    struct DiscreteGeometry{D,T} <: CSG.Geometry
+      tree::Node
+      point_to_coords::Vector{Point{D,T}}
+    end
+
+## Constructors
+
+    DiscreteGeometry(φh::FEFunction,model::DiscreteModel;name::String="")
+    DiscreteGeometry(f::Function,model::DiscreteModel;name::String="")
+
+"""
 struct DiscreteGeometry{D,T} <: CSG.Geometry
   tree::Node
   point_to_coords::Vector{Point{D,T}}
@@ -59,6 +71,11 @@ function _find_unique_leaves(tree)
   oid_to_j = Dict{UInt,Int}( [oid=>j for (j,oid) in enumerate(j_to_oid)] )
 
   j_to_fun, oid_to_j
+end
+
+function DiscreteGeometry(f::Function,model::DiscreteModel;name::String="")
+  geo = AnalyticalGeometry(f;name=name)
+  discretize(geo,model)
 end
 
 function DiscreteGeometry(

--- a/src/LevelSetCutters/LevelSetCutters.jl
+++ b/src/LevelSetCutters/LevelSetCutters.jl
@@ -15,6 +15,7 @@ import GridapEmbedded.Interfaces: compute_bgfacet_to_inoutcut
 using GridapEmbedded.Interfaces: Simplex
 using GridapEmbedded.Interfaces: merge_sub_face_data
 using GridapEmbedded.Interfaces: compute_inoutcut
+using GridapEmbedded.Interfaces: SubCellTriangulation, SubFacetTriangulation
 
 using LinearAlgebra
 using MiniQhull
@@ -54,6 +55,8 @@ include("DiscreteGeometries.jl")
 include("LookupTables.jl")
 
 include("CutTriangulations.jl")
+
+include("DifferentiableTriangulations.jl")
 
 struct LevelSetCutter <: Cutter end
 

--- a/src/LevelSetCutters/LevelSetCutters.jl
+++ b/src/LevelSetCutters/LevelSetCutters.jl
@@ -58,6 +58,19 @@ include("CutTriangulations.jl")
 
 include("DifferentiableTriangulations.jl")
 
+"""
+    struct LevelSetCutter <: Cutter end
+
+Cutter for `DiscreteGeometry` and `AnalyticalGeometry`.
+
+## Usage
+
+    cut(background::DiscreteModel,geom::AnalyticalGeometry)
+    cut(background::DiscreteModel,geom::DiscreteGeometry)
+    cut_facets(background::DiscreteModel,geom::AnalyticalGeometry)
+    cut_facets(background::DiscreteModel,geom::DiscreteGeometry)
+
+"""
 struct LevelSetCutter <: Cutter end
 
 function cut(cutter::LevelSetCutter,background::DiscreteModel,geom)

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -261,17 +261,14 @@ function main(distribute,np)
   n = 12
   model = generate_model(D,n,ranks,mesh_partition)
 
-  i_am_main(ranks) && println(" >> Case 0")
   φ0 = level_set(:circle_2)
   f0((x,y)) = VectorValue((1-x)^2,(1-y)^2)
   main_normal(model,φ0,f0)
 
-  i_am_main(ranks) && println(" >> Case 1")
   φ1 = level_set(:circle)
   f1(x) = 1.0
   main_generic(model,φ1,f1)
 
-  i_am_main(ranks) && println(" >> Case 2")
   φ2 = level_set(:circle)
   f2(x) = x[1] + x[2]
   main_generic(model,φ2,f2)
@@ -283,10 +280,9 @@ function main(distribute,np)
   n = 8
   model = generate_model(D,n,ranks,mesh_partition)
 
-  i_am_main(ranks) && println(" >> Case 3")
-  φ3 = level_set(:sphere)
-  f3(x) = x[1] + x[2]
-  main_generic(model,φ3,f3)
+  # φ3 = level_set(:sphere)
+  # f3(x) = x[1] + x[2]
+  # main_generic(model,φ3,f3)
 end
 
 end

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -17,6 +17,8 @@ using Gridap.Arrays: Operation
 using Gridap.CellData: get_tangent_vector, get_normal_vector
 using GridapEmbedded.Interfaces: get_conormal_vector, get_subfacet_normal_vector, get_ghost_normal_vector
 
+using GridapEmbedded.LevelSetCutters: DifferentiableTriangulation
+
 function generate_model(D,n,ranks,mesh_partition)
   domain = (D==2) ? (0,1,0,1) : (0,1,0,1,0,1)
   cell_partition = (D==2) ? (n,n) : (n,n,n)

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -284,8 +284,8 @@ function main(distribute,np)
   model = generate_model(D,n,ranks,mesh_partition)
 
   i_am_main(ranks) && println(" >> Case 3")
-  φ3 = level_set(:regular_3d)
-  f3(x) = x[1] + x[2] + x[3]
+  φ3 = level_set(:sphere)
+  f3(x) = x[1] + x[2]
   main_generic(model,φ3,f3)
 end
 

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -14,7 +14,8 @@ using GridapEmbedded, GridapEmbedded.Interfaces, GridapEmbedded.LevelSetCutters
 using GridapDistributed, PartitionedArrays
 
 using Gridap.Arrays: Operation
-using GridapTopOpt: get_conormal_vector,get_subfacet_normal_vector,get_ghost_normal_vector
+using Gridap.CellData: get_tangent_vector, get_normal_vector
+using GridapEmbedded.Interfaces: get_conormal_vector, get_subfacet_normal_vector, get_ghost_normal_vector
 
 function generate_model(D,n,ranks,mesh_partition)
   domain = (D==2) ? (0,1,0,1) : (0,1,0,1,0,1)

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -258,18 +258,21 @@ function main(distribute,np)
   mesh_partition = (2,2)
   ranks = distribute(LinearIndices((prod(mesh_partition),)))
   D = 2
-  n = 10
+  n = 12
   model = generate_model(D,n,ranks,mesh_partition)
 
+  i_am_main(ranks) && println(" >> Case 0")
   φ0 = level_set(:circle_2)
   f0((x,y)) = VectorValue((1-x)^2,(1-y)^2)
   main_normal(model,φ0,f0)
 
-  φ1 = level_set(:circle)
+  i_am_main(ranks) && println(" >> Case 1")
+  φ1 = level_set(:circle_2)
   f1(x) = 1.0
   main_generic(model,φ1,f1)
 
-  φ2 = level_set(:circle)
+  i_am_main(ranks) && println(" >> Case 2")
+  φ2 = level_set(:circle_2)
   f2(x) = x[1] + x[2]
   main_generic(model,φ2,f2)
 
@@ -280,6 +283,7 @@ function main(distribute,np)
   n = 8
   model = generate_model(D,n,ranks,mesh_partition)
 
+  i_am_main(ranks) && println(" >> Case 3")
   φ3 = level_set(:regular_3d)
   f3(x) = x[1] + x[2] + x[3]
   main_generic(model,φ3,f3)

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -267,12 +267,12 @@ function main(distribute,np)
   main_normal(model,φ0,f0)
 
   i_am_main(ranks) && println(" >> Case 1")
-  φ1 = level_set(:circle_2)
+  φ1 = level_set(:circle)
   f1(x) = 1.0
   main_generic(model,φ1,f1)
 
   i_am_main(ranks) && println(" >> Case 2")
-  φ2 = level_set(:circle_2)
+  φ2 = level_set(:circle)
   f2(x) = x[1] + x[2]
   main_generic(model,φ2,f2)
 

--- a/test/DistributedTests/GeometricalDifferentiationTests.jl
+++ b/test/DistributedTests/GeometricalDifferentiationTests.jl
@@ -1,0 +1,281 @@
+module DistributedGeometricalDifferentitationTests
+############################################################################################
+# These tests are meant to verify the correctness differentiation of functionals w.r.t the 
+# level set defining the cut domain. 
+# They are based on the following work:
+# "Level-set topology optimisation with unfitted finite elements and automatic shape differentiation"
+#   by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis (2025)
+############################################################################################
+using Test
+
+using Gridap, Gridap.Geometry, Gridap.Adaptivity
+using GridapEmbedded, GridapEmbedded.Interfaces, GridapEmbedded.LevelSetCutters
+
+using GridapDistributed, PartitionedArrays
+
+using Gridap.Arrays: Operation
+using GridapTopOpt: get_conormal_vector,get_subfacet_normal_vector,get_ghost_normal_vector
+
+function generate_model(D,n,ranks,mesh_partition)
+  domain = (D==2) ? (0,1,0,1) : (0,1,0,1,0,1)
+  cell_partition = (D==2) ? (n,n) : (n,n,n)
+  base_model = UnstructuredDiscreteModel(CartesianDiscreteModel(ranks,mesh_partition,domain,cell_partition))
+  ref_model = refine(base_model, refinement_method = "barycentric")
+  model = Adaptivity.get_model(ref_model)
+  return model
+end
+
+function level_set(shape::Symbol;N=4)
+  if shape == :square
+    x -> max(abs(x[1]-0.5),abs(x[2]-0.5))-0.25 # Square
+  elseif shape == :corner_2d
+    x -> ((x[1]-0.5)^N+(x[2]-0.5)^N)^(1/N)-0.25 # Curved corner
+  elseif shape == :diamond
+    x -> abs(x[1]-0.5)+abs(x[2]-0.5)-0.25-0/n/10 # Diamond
+  elseif shape == :circle
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2)-0.5223 # Circle
+  elseif shape == :circle_2
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2)-0.23 # Circle
+  elseif shape == :square_prism
+    x -> max(abs(x[1]-0.5),abs(x[2]-0.5),abs(x[3]-0.5))-0.25 # Square prism
+  elseif shape == :corner_3d
+    x -> ((x[1]-0.5)^N+(x[2]-0.5)^N+(x[3]-0.5)^N)^(1/N)-0.25 # Curved corner
+  elseif shape == :diamond_prism
+    x -> abs(x[1]-0.5)+abs(x[2]-0.5)+abs(x[3]-0.5)-0.25-0/n/10 # Diamond prism
+  elseif shape == :sphere
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2+(x[3]-0.5)^2)-0.53 # Sphere
+  elseif shape == :regular_2d
+    x -> cos(2π*x[1])*cos(2π*x[2])-0.11 # "Regular" LSF
+  elseif shape == :regular_3d
+    x -> cos(2π*x[1])*cos(2π*x[2])*cos(2π*x[3])-0.11 # "Regular" LSF
+  else
+    error("Unknown shape")
+  end
+end
+
+function main_generic(
+  model,φ::Function,f::Function
+)
+  order = 1
+  reffe = ReferenceFE(lagrangian,Float64,order)
+  V_φ = TestFESpace(model,reffe)
+
+  U = TestFESpace(model,reffe)
+
+  φh = interpolate(φ,V_φ)
+  fh = interpolate(f,V_φ)
+  uh = interpolate(x->x[1]+x[2],U)
+
+  geo = DiscreteGeometry(φh,model)
+  cutgeo = cut(model,geo)
+
+  # A.1) Volume integral
+
+  Ω = Triangulation(cutgeo,PHYSICAL_IN)
+  Ω_AD = DifferentiableTriangulation(Ω,V_φ)
+  dΩ = Measure(Ω_AD,2*order)
+
+  Γ = EmbeddedBoundary(cutgeo)
+  n_Γ = get_normal_vector(Γ)
+  dΓ = Measure(Γ,2*order)
+
+  J_bulk(φ) = ∫(fh)dΩ
+  dJ_bulk_AD = gradient(J_bulk,φh)
+  dJ_bulk_AD_vec = assemble_vector(dJ_bulk_AD,V_φ)
+
+  dJ_bulk_exact(q) = ∫(-fh*q/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJ_bulk_exact_vec = assemble_vector(dJ_bulk_exact,V_φ)
+
+  @test norm(dJ_bulk_AD_vec - dJ_bulk_exact_vec) < 1e-10
+
+  # A.1.1) Volume integral with another field
+
+  J_bulk_1(u,φ) = ∫(u+fh)dΩ
+  dJ_bulk_1_AD = gradient(φ->J_bulk_1(uh,φ),φh)
+  dJ_bulk_1_AD_vec = assemble_vector(dJ_bulk_1_AD,V_φ)
+
+  dJ_bulk_1_exact(q,u) = ∫(-(u+fh)*q/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJ_bulk_1_exact_vec = assemble_vector(q->dJ_bulk_1_exact(q,uh),V_φ)
+
+  @test norm(dJ_bulk_1_AD_vec - dJ_bulk_1_exact_vec) < 1e-10
+
+  J_bulk_1(u,φ) = ∫(u+fh)dΩ
+  dJ_bulk_1_AD_in_u = gradient(u->J_bulk_1(u,φh),uh)
+  dJ_bulk_1_AD_in_u_vec = assemble_vector(dJ_bulk_1_AD_in_u,U)
+
+  dJ_bulk_1_exact_in_u(q,u) = ∫(q)dΩ
+  dJ_bulk_1_exact_in_u_vec = assemble_vector(q->dJ_bulk_1_exact_in_u(q,uh),U)
+
+  @test norm(dJ_bulk_1_AD_in_u_vec - dJ_bulk_1_exact_in_u_vec) < 1e-10
+
+  # A.2) Volume integral
+
+  g(fh) = ∇(fh)⋅∇(fh)
+  J_bulk2(φ) = ∫(g(fh))dΩ
+  dJ_bulk_AD2 = gradient(J_bulk2,φh)
+  dJ_bulk_AD_vec2 = assemble_vector(dJ_bulk_AD2,V_φ)
+
+  dJ_bulk_exact2(q) = ∫(-g(fh)*q/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJ_bulk_exact_vec2 = assemble_vector(dJ_bulk_exact2,V_φ)
+
+  @test norm(dJ_bulk_AD_vec2 - dJ_bulk_exact_vec2) < 1e-10
+
+  # B.1) Facet integral
+
+  Γ = EmbeddedBoundary(cutgeo)
+  n_Γ = get_normal_vector(Γ)
+  Γ_AD = DifferentiableTriangulation(Γ,V_φ)
+  Λ = Skeleton(Γ)
+  Σ = Boundary(Γ)
+
+  dΓ = Measure(Γ,2*order)
+  dΛ = Measure(Λ,2*order)
+  dΣ = Measure(Σ,2*order)
+
+  n_Γ = get_normal_vector(Γ)
+
+  n_S_Λ = get_normal_vector(Λ)
+  m_k_Λ = get_conormal_vector(Λ)
+  ∇ˢφ_Λ = Operation(abs)(n_S_Λ ⋅ ∇(φh).plus)
+
+  n_S_Σ = get_normal_vector(Σ)
+  m_k_Σ = get_conormal_vector(Σ)
+  ∇ˢφ_Σ = Operation(abs)(n_S_Σ ⋅ ∇(φh))
+
+  dΓ_AD = Measure(Γ_AD,2*order)
+  J_int(φ) = ∫(fh)dΓ_AD
+  dJ_int_AD = gradient(J_int,φh)
+  dJ_int_AD_vec = assemble_vector(dJ_int_AD,V_φ)
+
+  dJ_int_exact(w) = ∫((-n_Γ⋅∇(fh))*w/(abs(n_Γ ⋅ ∇(φh))))dΓ +
+                    ∫(-n_S_Λ ⋅ (jump(fh*m_k_Λ) * mean(w) / ∇ˢφ_Λ))dΛ +
+                    ∫(-n_S_Σ ⋅ (fh*m_k_Σ * w / ∇ˢφ_Σ))dΣ
+  dJ_int_exact_vec = assemble_vector(dJ_int_exact,V_φ)
+
+  @test norm(dJ_int_AD_vec - dJ_int_exact_vec) < 1e-10
+
+  # B.2) Facet integral
+  g(fh) = ∇(fh)⋅∇(fh)
+
+  J_int2(φ) = ∫(g(fh))dΓ_AD
+  dJ_int_AD2 = gradient(J_int2,φh)
+  dJ_int_AD_vec2 = assemble_vector(dJ_int_AD2,V_φ)
+
+  ∇g(∇∇f,∇f) = ∇∇f⋅∇f + ∇f⋅∇∇f
+  dJ_int_exact2(w) = ∫((-n_Γ⋅ (∇g ∘ (∇∇(fh),∇(fh))))*w/(abs(n_Γ ⋅ ∇(φh))))dΓ +
+                    ∫(-n_S_Λ ⋅ (jump(g(fh)*m_k_Λ) * mean(w) / ∇ˢφ_Λ))dΛ +
+                    ∫(-n_S_Σ ⋅ (g(fh)*m_k_Σ * w / ∇ˢφ_Σ))dΣ
+  dJ_int_exact_vec2 = assemble_vector(dJ_int_exact2,V_φ)
+
+  @test norm(dJ_int_AD_vec2 - dJ_int_exact_vec2) < 1e-10
+
+end
+
+## Concering integrals of the form `φ->∫(f ⋅ n(φ))dΓ(φ)`
+function main_normal(
+  model,φ::Function,f::Function;
+  vtk=false,
+  name="embedded",
+  run_test=true
+)
+  order = 1
+  reffe = ReferenceFE(lagrangian,Float64,order)
+  V_φ = TestFESpace(model,reffe)
+
+  φh = interpolate(φ,V_φ)
+
+  geo = DiscreteGeometry(φh,model)
+  cutgeo = cut(model,geo)
+
+  Γ = EmbeddedBoundary(cutgeo)
+  n_Γ = get_normal_vector(Γ)
+  Γ_AD = DifferentiableTriangulation(Γ,V_φ)
+  dΓ_AD = Measure(Γ_AD,2*order)
+  dΓ = Measure(Γ,2*order)
+
+  fh_Γ = CellField(f,Γ)
+  fh_Γ_AD = CellField(f,Γ_AD)
+
+  function J_int(φ)
+    n = get_normal_vector(Γ_AD)
+    ∫(fh_Γ_AD⋅n)dΓ_AD
+  end
+  dJ_int_AD = gradient(J_int,φh)
+  dJ_int_AD_vec = assemble_vector(dJ_int_AD,V_φ)
+
+  _n(∇φ) = ∇φ/(10^-20+norm(∇φ))
+  dJ_int_phi = ∇(φ->∫(fh_Γ_AD ⋅ (_n ∘ (∇(φ))))dΓ_AD,φh)
+  dJh_int_phi = assemble_vector(dJ_int_phi,V_φ)
+
+  run_test && @test norm(dJ_int_AD_vec - dJh_int_phi) < 1e-10
+
+  # Analytic
+  # Note: currently, the analytic result is only valid on closed domains thanks
+  #   to the divergence theorem. I think it would take significant work to compute
+  #   the analytic derivative generally as we can't rely on divergence theorem to
+  #   rewrite it in a convenient way. As a result, we don't have an analytic result
+  #   for general cases such as ∫( f(n(φ)) )dΓ(φ), nor the case when Γ intersects
+  #   ∂D. Thankfully, we have AD instead ;)
+  # Note 2: For the case that Γ does intersect the surface, the result is correct
+  #   everywhere except on the intersection.
+
+  fh2(x) = VectorValue((1-x[1])^2,(1-x[2])^2)
+  fh_Γ = CellField(fh2,Γ)
+  fh_Γ_AD = CellField(fh2,Γ_AD)
+
+  # Note: this comes from rewriting via the divergence theorem:
+  #         ∫(f ⋅ n(φ))dΓ(φ) = ∫(∇⋅f)dΩ(φ)
+  dJ_int_exact3(w) = ∫(-(∇⋅(fh_Γ))*w/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJh_int_exact3 = assemble_vector(dJ_int_exact3,V_φ)
+
+  run_test && @test norm(dJh_int_exact3 - dJ_int_AD_vec) < 1e-10
+
+  if vtk
+    path = "results/$(name)"
+    Ω_bg = Triangulation(model)
+    writevtk(Ω_bg,path,cellfields=[
+      "dJ_AD"=>FEFunction(V_φ,dJ_int_AD_vec),
+      "dJ_AD_with_phi"=>FEFunction(V_φ,dJh_int_phi),
+      "dJ_exact"=>FEFunction(V_φ,dJh_int_exact3)
+      ])
+  end
+end
+
+#######################
+
+function main(distribute,np)
+  @assert np == 4
+
+  # 2D
+  mesh_partition = (2,2)
+  ranks = distribute(LinearIndices((prod(mesh_partition),)))
+  D = 2
+  n = 10
+  model = generate_model(D,n,ranks,mesh_partition)
+
+  φ0 = level_set(:circle_2)
+  f0((x,y)) = VectorValue((1-x)^2,(1-y)^2)
+  main_normal(model,φ0,f0;vtk=true)
+
+  φ1 = level_set(:circle)
+  f1 = x -> 1.0
+  main_generic(model,φ1,f1)
+
+  model = generate_model(D,n,ranks,mesh_partition)
+  φ2 = level_set(:circle)
+  f2 = x -> x[1]+x[2]
+  main_generic(model,φ2,f2)
+
+  # 3D
+  mesh_partition = (2,2,1)
+  ranks = distribute(LinearIndices((prod(mesh_partition),)))
+  D = 3
+  n = 8
+  model = generate_model(D,n,ranks,mesh_partition)
+
+  φ3 = level_set(:regular_3d)
+  f3 = x -> x[1]+x[2]
+  main_generic(model,φ3,f3)
+end
+
+end

--- a/test/DistributedTests/mpi/runtests_body.jl
+++ b/test/DistributedTests/mpi/runtests_body.jl
@@ -9,6 +9,7 @@ include("../AggregatesTests.jl")
 include("../DistributedDiscreteGeometryPoissonTest.jl")
 include("../DistributedLSDiscreteGeometryPoissonTest.jl")
 include("../PeriodicDistributedDiscreteGeometryPoissonTest.jl")
+include("../GeometricalDifferentiationTests.jl")
 
 if ! MPI.Initialized()
   MPI.Init()
@@ -41,6 +42,7 @@ function all_tests(distribute,parts)
 
   if prod(parts) == 4
     DistributedAggregatesTests.main(distribute,parts)
+    DistributedGeometricalDifferentitationTests.main(distribute,4)
   end
   PArrays.toc!(t,"Aggregates")
 

--- a/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
+++ b/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
@@ -8,6 +8,9 @@ using Gridap.Geometry
 using GridapEmbedded.Interfaces
 using GridapEmbedded.LevelSetCutters
 
+##########################################
+# 2D tests 
+
 n = 10
 partition = (n,n)
 domain = (0,1,0,1)
@@ -36,6 +39,8 @@ u = interpolate(x->x[1]+x[2],V)
 Γf = BoundaryTriangulation(cutgeo_facets,PHYSICAL)
 Γ = lazy_append(Γu,Γf)
 Λ = SkeletonTriangulation(cutgeo_facets,PHYSICAL)
+
+face_model = get_active_model(Γu)
 
 test_triangulation(Ω)
 test_triangulation(Γ)
@@ -69,15 +74,19 @@ celldata_Λ = [
  "bgcell_right"=>collect(Int,get_glue(Λ.⁻,Val(D)).tface_to_mface)]
 cellfields_Λ = ["normal"=> n_Λ.⁺,"jump_v"=>jump(v),"jump_u"=>jump(u)]
 
-d = mktempdir()
+d = "./dev"#mktempdir()
 try
-  writevtk(Ωbg,joinpath(d,"trian"))
-  writevtk(Ω,joinpath(d,"trian_O"),celldata=celldata_Ω,cellfields=cellfields_Ω)
-  writevtk(Γ,joinpath(d,"trian_G"),celldata=celldata_Γ,cellfields=cellfields_Γ)
-  writevtk(Λ,joinpath(d,"trian_sO"),celldata=celldata_Λ,cellfields=cellfields_Λ)
+  writevtk(Ωbg,joinpath(d,"trian"),append=false)
+  writevtk(Ω,joinpath(d,"trian_O"),celldata=celldata_Ω,cellfields=cellfields_Ω,append=false)
+  writevtk(Γ,joinpath(d,"trian_G"),celldata=celldata_Γ,cellfields=cellfields_Γ,append=false)
+  writevtk(Λ,joinpath(d,"trian_sO"),celldata=celldata_Λ,cellfields=cellfields_Λ,append=false)
+  writevtk(Γf,joinpath(d,"trian_Gf"),append=false)
 finally
-  rm(d,recursive=true)
+  #rm(d,recursive=true)
 end
+
+##########################################
+# 3D tests 
 
 n = 10
 partition = (n,n,n)
@@ -95,11 +104,14 @@ trian_s = SkeletonTriangulation(bgmodel)
 trian_sΩ = SkeletonTriangulation(trian_s,cutgeo_facets,PHYSICAL_IN,geo)
 trian_sΩo = SkeletonTriangulation(trian_s,cutgeo_facets,PHYSICAL_OUT,geo)
 
+Γu = EmbeddedBoundary(cutgeo)
+face_model = get_active_model(Γu)
+
 d = mktempdir()
 try
-writevtk(trian_s,joinpath(d,"trian_s"))
-writevtk(trian_sΩ,joinpath(d,"trian_sO"))
-writevtk(trian_sΩo,joinpath(d,"trian_sOo"))
+  writevtk(trian_s,joinpath(d,"trian_s"))
+  writevtk(trian_sΩ,joinpath(d,"trian_sO"))
+  writevtk(trian_sΩo,joinpath(d,"trian_sOo"))
 finally
   rm(d,recursive=true)
 end

--- a/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
+++ b/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
@@ -41,6 +41,8 @@ u = interpolate(x->x[1]+x[2],V)
 Λ = SkeletonTriangulation(cutgeo_facets,PHYSICAL)
 
 face_model = get_active_model(Γu)
+Σb = BoundaryTriangulation(Γu)
+Σi = SkeletonTriangulation(Γu)
 
 test_triangulation(Ω)
 test_triangulation(Γ)

--- a/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
+++ b/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
@@ -108,6 +108,8 @@ trian_sΩo = SkeletonTriangulation(trian_s,cutgeo_facets,PHYSICAL_OUT,geo)
 
 Γu = EmbeddedBoundary(cutgeo)
 face_model = get_active_model(Γu)
+Σb = BoundaryTriangulation(Γu)
+Σi = SkeletonTriangulation(Γu)
 
 d = mktempdir()
 try

--- a/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
+++ b/test/InterfacesTests/EmbeddedFacetDiscretizationsTests.jl
@@ -76,7 +76,7 @@ celldata_Λ = [
  "bgcell_right"=>collect(Int,get_glue(Λ.⁻,Val(D)).tface_to_mface)]
 cellfields_Λ = ["normal"=> n_Λ.⁺,"jump_v"=>jump(v),"jump_u"=>jump(u)]
 
-d = "./dev"#mktempdir()
+d = mktempdir()
 try
   writevtk(Ωbg,joinpath(d,"trian"),append=false)
   writevtk(Ω,joinpath(d,"trian_O"),celldata=celldata_Ω,cellfields=cellfields_Ω,append=false)
@@ -84,7 +84,7 @@ try
   writevtk(Λ,joinpath(d,"trian_sO"),celldata=celldata_Λ,cellfields=cellfields_Λ,append=false)
   writevtk(Γf,joinpath(d,"trian_Gf"),append=false)
 finally
-  #rm(d,recursive=true)
+  rm(d,recursive=true)
 end
 
 ##########################################

--- a/test/LevelSetCuttersTests/GeometricalDifferentiationTests.jl
+++ b/test/LevelSetCuttersTests/GeometricalDifferentiationTests.jl
@@ -1,0 +1,513 @@
+module GeometricalDifferentiationTests
+############################################################################################
+# These tests are meant to verify the correctness differentiation of functionals w.r.t the 
+# level set defining the cut domain. 
+# They are based on the following work:
+# "Level-set topology optimisation with unfitted finite elements and automatic shape differentiation"
+#   by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis, CMAME (2025)
+############################################################################################
+using Test, FiniteDiff
+
+using Gridap, Gridap.Geometry, Gridap.Adaptivity, Gridap.Arrays
+using GridapEmbedded, GridapEmbedded.LevelSetCutters, GridapEmbedded.Interfaces
+
+using GridapEmbedded.Interfaces: get_conormal_vector
+using GridapEmbedded.Interfaces: get_subfacet_normal_vector
+using GridapEmbedded.Interfaces: get_ghost_normal_vector
+
+using GridapEmbedded.LevelSetCutters: DifferentiableTriangulation
+
+
+using Gridap.Fields, Gridap.Polynomials
+function Arrays.return_cache(
+  fg::Fields.FieldGradientArray{1,Polynomials.MonomialBasis{D,V}},
+  x::AbstractVector{<:Point}) where {D,V}
+  xi = testitem(x)
+  T = gradient_type(V,xi)
+  Polynomials._return_cache(fg,x,T,Val(false))
+end
+
+function Arrays.evaluate!(
+  cache,
+  fg::Fields.FieldGradientArray{1,Polynomials.MonomialBasis{D,V}},
+  x::AbstractVector{<:Point}) where {D,V}
+  Polynomials._evaluate!(cache,fg,x,Val(false))
+end
+
+# We general a simplicial model where the simplices are created in a symmetric way using 
+# varycentric refinement of QUADs and HEXs.
+function generate_model(D,n)
+  domain = (D==2) ? (0,1,0,1) : (0,1,0,1,0,1)
+  cell_partition = (D==2) ? (n,n) : (n,n,n)
+  base_model = UnstructuredDiscreteModel((CartesianDiscreteModel(domain,cell_partition)))
+  ref_model = refine(base_model, refinement_method = "barycentric")
+  model = ref_model.model
+  return model
+end
+
+function level_set(shape::Symbol;N=4)
+  if shape == :square
+    x -> max(abs(x[1]-0.5),abs(x[2]-0.5))-0.25 # Square
+  elseif shape == :corner_2d
+    x -> ((x[1]-0.5)^N+(x[2]-0.5)^N)^(1/N)-0.25 # Curved corner
+  elseif shape == :diamond
+    x -> abs(x[1]-0.5)+abs(x[2]-0.5)-0.25-0/n/10 # Diamond
+  elseif shape == :circle
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2)-0.5223 # Circle
+  elseif shape == :circle_2
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2)-0.23 # Circle
+  elseif shape == :square_prism
+    x -> max(abs(x[1]-0.5),abs(x[2]-0.5),abs(x[3]-0.5))-0.25 # Square prism
+  elseif shape == :corner_3d
+    x -> ((x[1]-0.5)^N+(x[2]-0.5)^N+(x[3]-0.5)^N)^(1/N)-0.25 # Curved corner
+  elseif shape == :diamond_prism
+    x -> abs(x[1]-0.5)+abs(x[2]-0.5)+abs(x[3]-0.5)-0.25-0/n/10 # Diamond prism
+  elseif shape == :sphere
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2+(x[3]-0.5)^2)-0.53 # Sphere
+  elseif shape == :sphere_2
+    x -> sqrt((x[1]-0.5)^2+(x[2]-0.5)^2+(x[3]-0.5)^2)-0.23 # Sphere
+  elseif shape == :regular_2d
+    x -> cos(2π*x[1])*cos(2π*x[2])-0.11 # "Regular" LSF
+  elseif shape == :regular_3d
+    x -> cos(2π*x[1])*cos(2π*x[2])*cos(2π*x[3])-0.11 # "Regular" LSF
+  else
+    error("Unknown shape")
+  end
+end
+
+function main(
+  model,ls::Function,f::Function;
+  vtk=false,
+  name="embedded",
+  verbose=false,
+  fdm=false
+)
+  order = 1
+  reffe = ReferenceFE(lagrangian,Float64,order)
+  V_φ = TestFESpace(model,reffe)
+
+  U = TestFESpace(model,reffe)
+
+  φh = interpolate(ls,V_φ)
+  fh = interpolate(f,V_φ)
+  uh = interpolate(x->x[1]+x[2],U)
+
+  # Correction if level set is on top of a node
+  x_φ = get_free_dof_values(φh)
+  idx = findall(isapprox(0.0;atol=10^-10),x_φ)
+  !isempty(idx) && @info "Correcting level values!"
+  x_φ[idx] .+= 100*eps(eltype(x_φ))
+
+  geo = DiscreteGeometry(φh,model)
+  cutgeo = cut(model,geo)
+
+  # A.1) Volume integral
+
+  Ω = Triangulation(cutgeo,PHYSICAL_IN)
+  Ω_AD = DifferentiableTriangulation(Ω,V_φ)
+  dΩ = Measure(Ω_AD,2*order)
+
+  Γ = EmbeddedBoundary(cutgeo)
+  n_Γ = get_normal_vector(Γ)
+  dΓ = Measure(Γ,2*order)
+
+  J_bulk(φ) = ∫(fh)dΩ
+  dJ_bulk_AD = gradient(J_bulk,φh)
+  dJ_bulk_AD_vec = assemble_vector(dJ_bulk_AD,V_φ)
+
+  dJ_bulk_exact(q) = ∫(-fh*q/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJ_bulk_exact_vec = assemble_vector(dJ_bulk_exact,V_φ)
+
+  abs_error = norm(dJ_bulk_AD_vec - dJ_bulk_exact_vec,Inf)
+
+  if fdm
+    function J_fdm_bulk(φ)
+      φh = FEFunction(V_φ,φ)
+      cutgeo = cut(model,DiscreteGeometry(φh,model))
+      Ω = Triangulation(cutgeo,PHYSICAL_IN)
+      dΩ = Measure(Ω,2*order)
+      sum(∫(fh)dΩ)
+    end
+    dJ_FD = FiniteDiff.finite_difference_gradient(J_fdm_bulk,get_free_dof_values(φh))
+
+    abs_error_fdm = norm(dJ_bulk_AD_vec - dJ_FD,Inf)
+  end
+
+  if verbose
+    println("A.1) Volume integral:")
+    println("  - norm(dJ_AD - dJ_exact,Inf) = ",abs_error)
+    fdm && println("  - norm(dJ_AD - dJ_FDM,Inf) = ",abs_error_fdm)
+  end
+
+  @test abs_error < 1e-10
+
+  # A.1.1) Volume integral with another field
+
+  J_bulk_1(u,φ) = ∫(u+fh)dΩ
+  dJ_bulk_1_AD = gradient(φ->J_bulk_1(uh,φ),φh)
+  dJ_bulk_1_AD_vec = assemble_vector(dJ_bulk_1_AD,V_φ)
+
+  dJ_bulk_1_exact(q,u) = ∫(-(u+fh)*q/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJ_bulk_1_exact_vec = assemble_vector(q->dJ_bulk_1_exact(q,uh),V_φ)
+  @test norm(dJ_bulk_1_AD_vec - dJ_bulk_1_exact_vec) < 1e-10
+
+  dJ_bulk_1_AD_in_u = gradient(u->J_bulk_1(u,φh),uh)
+  dJ_bulk_1_AD_in_u_vec = assemble_vector(dJ_bulk_1_AD_in_u,U)
+  dJ_bulk_1_exact_in_u(q,u) = ∫(q)dΩ
+  dJ_bulk_1_exact_in_u_vec = assemble_vector(q->dJ_bulk_1_exact_in_u(q,uh),U)
+
+  abs_error = norm(dJ_bulk_1_AD_in_u_vec - dJ_bulk_1_exact_in_u_vec,Inf)
+  if verbose
+    println("A.1.1) Volume integral with another field:")
+    println("  - norm(dJ_AD - dJ_exact,Inf) = ",abs_error)
+  end
+  @test abs_error < 1e-10
+
+  # A.2) Volume integral
+
+  g(fh) = ∇(fh)⋅∇(fh)
+  J_bulk2(φ) = ∫(g(fh))dΩ
+  dJ_bulk_AD2 = gradient(J_bulk2,φh)
+  dJ_bulk_AD_vec2 = assemble_vector(dJ_bulk_AD2,V_φ)
+
+  dJ_bulk_exact2(q) = ∫(-g(fh)*q/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJ_bulk_exact_vec2 = assemble_vector(dJ_bulk_exact2,V_φ)
+
+  abs_error = norm(dJ_bulk_AD_vec2 - dJ_bulk_exact_vec2,Inf)
+
+  if verbose
+    println("A.2) Volume integral with grad of fields:")
+    println("  - norm(dJ_AD - dJ_exact,Inf) = ",abs_error)
+  end
+
+  @test abs_error < 1e-10
+
+  # B.1) Facet integral
+
+  Γ = EmbeddedBoundary(cutgeo)
+  Γ_AD = DifferentiableTriangulation(Γ,V_φ)
+  Λ = Skeleton(Γ)
+  Σ = Boundary(Γ)
+
+  dΓ = Measure(Γ,2*order)
+  dΛ = Measure(Λ,2*order)
+  dΣ = Measure(Σ,2*order)
+
+  n_Γ = get_normal_vector(Γ)
+
+  n_S_Λ = get_normal_vector(Λ)
+  m_k_Λ = get_conormal_vector(Λ)
+  ∇ˢφ_Λ = Operation(abs)(n_S_Λ ⋅ ∇(φh).plus)
+
+  n_S_Σ = get_normal_vector(Σ)
+  m_k_Σ = get_conormal_vector(Σ)
+  ∇ˢφ_Σ = Operation(abs)(n_S_Σ ⋅ ∇(φh))
+
+  dΓ_AD = Measure(Γ_AD,2*order)
+  J_int(φ) = ∫(fh)dΓ_AD
+  dJ_int_AD = gradient(J_int,φh)
+  dJ_int_AD_vec = assemble_vector(dJ_int_AD,V_φ)
+
+  dJ_int_exact(w) = ∫((-n_Γ⋅∇(fh))*w/(abs(n_Γ ⋅ ∇(φh))))dΓ +
+                    ∫(-n_S_Λ ⋅ (jump(fh*m_k_Λ) * mean(w) / ∇ˢφ_Λ))dΛ +
+                    ∫(-n_S_Σ ⋅ (fh*m_k_Σ * w / ∇ˢφ_Σ))dΣ
+  dJ_int_exact_vec = assemble_vector(dJ_int_exact,V_φ)
+
+  abs_error = norm(dJ_int_AD_vec - dJ_int_exact_vec,Inf)
+
+  if fdm
+    Ω_data = EmbeddedCollection(model,φh) do cutgeo,_,_
+      Γ_AD = DifferentiableTriangulation(EmbeddedBoundary(cutgeo),V_φ)
+      (;:dΓ_AD => Measure(Γ_AD,2*order))
+    end
+    function J_fdm_surf(φ)
+      sum(∫(fh)Ω_data.dΓ_AD)
+    end
+    dJ_surf_FD = FiniteDiff.finite_difference_gradient(J_fdm_surf,get_free_dof_values(φh))
+
+    abs_error_fdm = norm(dJ_int_AD_vec - dJ_surf_FD,Inf)
+  end
+
+  if verbose
+    println("B.1) Surface integral:")
+    println("  - norm(dJ_AD - dJ_exact,Inf) = ",abs_error)
+    fdm && println("  - norm(dJ_AD - dJ_FDM,Inf) = ",abs_error_fdm)
+  end
+  @test abs_error < 1e-10
+
+  # B.2) Facet integral
+  g(fh) = ∇(fh)⋅∇(fh)
+  ∇g(∇∇f,∇f) = ∇∇f⋅∇f + ∇f⋅∇∇f
+
+  J_int2(φ) = ∫(g(fh))dΓ_AD
+  dJ_int_AD2 = gradient(J_int2,φh)
+  dJ_int_AD_vec2 = assemble_vector(dJ_int_AD2,V_φ)
+
+  dJ_int_exact2(w) = ∫((-n_Γ⋅ (∇g ∘ (∇∇(fh),∇(fh))))*w/(abs(n_Γ ⋅ ∇(φh))))dΓ +
+                    ∫(-n_S_Λ ⋅ (jump(g(fh)*m_k_Λ) * mean(w) / ∇ˢφ_Λ))dΛ +
+                    ∫(-n_S_Σ ⋅ (g(fh)*m_k_Σ * w / ∇ˢφ_Σ))dΣ
+  dJ_int_exact_vec2 = assemble_vector(dJ_int_exact2,V_φ)
+
+  abs_error = norm(dJ_int_AD_vec2 - dJ_int_exact_vec2,Inf)
+  if verbose
+    println("B.2) Surface integral with grad of other fields:")
+    println("  - norm(dJ_AD - dJ_exact,Inf) = ",abs_error)
+  end
+  @test abs_error < 1e-10
+
+  if vtk
+    path = "results/$(name)/"
+    mkpath(path)
+    Ω_bg = Triangulation(model)
+    writevtk(
+      Ω_bg,"$(path)results",
+      cellfields = [
+        "φh" => φh,"∇φh" => ∇(φh),
+        "dJ_bulk_AD" => FEFunction(V_φ,dJ_bulk_AD_vec),
+        "dJ_bulk_exact" => FEFunction(V_φ,dJ_bulk_exact_vec),
+        "dJ_int_AD" => FEFunction(V_φ,dJ_int_AD_vec),
+        "dJ_int_exact" => FEFunction(V_φ,dJ_int_exact_vec)
+      ],
+      celldata = [
+        "inoutcut" => GridapEmbedded.Interfaces.compute_bgcell_to_inoutcut(model,geo)
+      ];
+      append = false
+    )
+
+    writevtk(
+      Ω, "$(path)omega"; append = false
+    )
+    writevtk(
+      Γ, "$(path)gamma"; append = false
+    )
+
+    n_∂Ω_Λ = get_subfacet_normal_vector(Λ)
+    n_k_Λ  = get_ghost_normal_vector(Λ)
+    writevtk(
+      Λ, "$(path)_lambda",
+      cellfields = [
+        "n_∂Ω.plus" => n_∂Ω_Λ.plus,"n_∂Ω.minus" => n_∂Ω_Λ.minus,
+        "n_k.plus" => n_k_Λ.plus,"n_k.minus" => n_k_Λ.minus,
+        "n_S" => n_S_Λ,
+        "m_k.plus" => m_k_Λ.plus,"m_k.minus" => m_k_Λ.minus,
+        "∇ˢφ" => ∇ˢφ_Λ,
+        "∇φh_Γs_plus" => ∇(φh).plus,"∇φh_Γs_minus" => ∇(φh).minus,
+        "jump(fh*m_k)" => jump(fh*m_k_Λ)
+      ];
+      append = false
+    )
+
+    if num_cells(Σ) > 0
+      n_∂Ω_Σ = get_subfacet_normal_vector(Σ)
+      n_k_Σ  = get_ghost_normal_vector(Σ)
+      writevtk(
+        Σ, "$(path)_sigma",
+        cellfields = [
+          "n_∂Ω" => n_∂Ω_Σ, "n_k" => n_k_Σ,
+          "n_S" => n_S_Σ, "m_k" => m_k_Σ,
+          "∇ˢφ" => ∇ˢφ_Σ, "∇φh_Γs" => ∇(φh),
+        ];
+        append = false
+      )
+    end
+  end
+end
+
+## Concering integrals of the form `φ->∫(f ⋅ n(φ))dΓ(φ)`
+function main_normal(
+  model,ls::Function,f_vec::Function;
+  vtk=false,
+  name="flux integrals",
+  run_test=true,
+  verbose=false,
+  fdm=false
+)
+  order = 1
+  reffe = ReferenceFE(lagrangian,Float64,order)
+  V_φ = TestFESpace(model,reffe)
+
+  φh = interpolate(ls,V_φ)
+
+  # Correction if level set is on top of a node
+  x_φ = get_free_dof_values(φh)
+  idx = findall(isapprox(0.0;atol=10^-10),x_φ)
+  !isempty(idx) && @info "Correcting level values!"
+  x_φ[idx] .+= 100*eps(eltype(x_φ))
+
+  geo = DiscreteGeometry(φh,model)
+  cutgeo = cut(model,geo)
+
+  Γ = EmbeddedBoundary(cutgeo)
+  n_Γ = get_normal_vector(Γ)
+  Γ_AD = DifferentiableTriangulation(Γ,V_φ)
+  dΓ_AD = Measure(Γ_AD,2*order)
+  dΓ = Measure(Γ,2*order)
+
+  fh_Γ = CellField(f_vec,Γ)
+  fh_Γ_AD = CellField(f_vec,Γ_AD)
+
+  function J_int(φ)
+    n = get_normal_vector(Γ_AD)
+    ∫(fh_Γ_AD⋅n)dΓ_AD
+  end
+  dJ_int_AD = gradient(J_int,φh)
+  dJ_int_AD_vec = assemble_vector(dJ_int_AD,V_φ)
+
+  _n(∇φ) = ∇φ/(10^-20+norm(∇φ))
+  dJ_int_phi = ∇(φ->∫(fh_Γ_AD ⋅ (_n ∘ (∇(φ))))dΓ_AD,φh)
+  dJh_int_phi = assemble_vector(dJ_int_phi,V_φ)
+
+  run_test && @test norm(dJ_int_AD_vec - dJh_int_phi) < 1e-10
+
+  # Analytic
+  # Note: currently, the analytic result is only valid on closed domains thanks
+  #   to the divergence theorem. I think it would take significant work to compute
+  #   the analytic derivative generally as we can't rely on divergence theorem to
+  #   rewrite it in a convenient way. As a result, we don't have an analytic result
+  #   for general cases such as ∫( f(n(φ)) )dΓ(φ), nor the case when Γ intersects
+  #   ∂D. Thankfully, we have AD instead ;)
+  # Note 2: For the case that Γ does intersect the surface, the result is correct
+  #   everywhere except on the intersection.
+
+  fh_Γ = CellField(f_vec,Γ)
+  fh_Γ_AD = CellField(f_vec,Γ_AD)
+
+  # Note: this comes from rewriting via the divergence theorem:
+  #         ∫(f ⋅ n(φ))dΓ(φ) = ∫(∇⋅f)dΩ(φ)
+  dJ_int_exact3(w) = ∫(-(∇⋅(fh_Γ))*w/(abs(n_Γ ⋅ ∇(φh))))dΓ
+  dJh_int_exact3 = assemble_vector(dJ_int_exact3,V_φ)
+
+  # Finite diff
+  if fdm
+    function J_fdm_surf(φ)
+      φh = FEFunction(V_φ,φ)
+      cutgeo = cut(model,DiscreteGeometry(φh,model))
+      Γ = EmbeddedBoundary(cutgeo)
+      dΓ = Measure(Γ,2*order)
+      n = get_normal_vector(Γ)
+      f = CellField(f_vec,Γ)
+      n = get_normal_vector(Γ)
+      sum(∫(f⋅n)dΓ)
+    end
+    dJ_FD = FiniteDiff.finite_difference_gradient(J_fdm_surf,get_free_dof_values(φh))
+
+    abs_error_fdm = norm(dJ_int_AD_vec - dJ_FD,Inf)
+  end
+  abs_error = norm(dJh_int_exact3 - dJ_int_AD_vec,Inf)
+
+  if verbose
+    println("C) Flux integral:")
+    println("  - norm(dJ_AD - dJ_exact,Inf) = ",abs_error)
+    fdm && println("  - norm(dJ_AD - dJ_FDM,Inf) = ",abs_error_fdm)
+  end
+
+  run_test && @test abs_error < 1e-10
+
+  if vtk
+    path = "results/$(name)/"
+    mkpath(path)
+    Ω_bg = Triangulation(model)
+    writevtk(Ω_bg,path*"Results",cellfields=[
+      "dJ_AD"=>FEFunction(V_φ,dJ_int_AD_vec),
+      "dJ_AD_with_phi"=>FEFunction(V_φ,dJh_int_phi),
+      "dJ_exact"=>FEFunction(V_φ,dJh_int_exact3)
+      ])
+    writevtk(Γ,path*"Gamma")
+  end
+end
+
+# Finite difference verification of gradients of integrals of the form `φ->∫(f(n))dΓ(φ)` and Hessian's.
+#   Both of these do not currently have rigorous mathematical counterparts so we verify them
+#   with finite differences.
+function main_fdm_only_verif(model,ls::Function;
+    verbose=false,compute_hess=false,fdm=false
+)
+  order = 1
+  reffe = ReferenceFE(lagrangian,Float64,order)
+  V_φ = TestFESpace(model,reffe)
+  φh = interpolate(ls,V_φ)
+
+  # Correction if level set is on top of a node
+  x_φ = get_free_dof_values(φh)
+  idx = findall(isapprox(0.0;atol=10^-10),x_φ)
+  !isempty(idx) && @info "Correcting level values!"
+  x_φ[idx] .+= 100*eps(eltype(x_φ))
+
+  geo = DiscreteGeometry(φh,model)
+  cutgeo = cut(model,geo)
+
+  Γ = EmbeddedBoundary(cutgeo)
+  Γ_AD = DifferentiableTriangulation(Γ,V_φ)
+  dΓ_AD = Measure(Γ_AD,2*order)
+
+  # Sec 6.2 - 10.1007/s00466-017-1383-6
+  g((x,y)) = x - 1/10*sin(2π*y/6)
+  gh = interpolate(g,V_φ)
+  _n_g(∇g) = ∇g/(10^-20+norm(∇g))
+  n_g = _n_g ∘ ∇(gh)
+  j(x) = norm(x)^2
+
+  function J_int(φ)
+    n = get_normal_vector(Γ_AD)
+    ∫(j ∘ (n-n_g))dΓ_AD
+  end
+  dJ_int_AD = gradient(J_int,φh)
+  dJ_int_AD_vec = assemble_vector(dJ_int_AD,V_φ)
+  hess = hessian(J_int,φh)
+  d²J = assemble_matrix(hess,V_φ,V_φ)
+
+  # Finite diff
+  if fdm
+    function J_fdm_surf(φ)
+      φh = FEFunction(V_φ,φ)
+      cutgeo = cut(model,DiscreteGeometry(φh,model))
+      Γ = EmbeddedBoundary(cutgeo)
+      dΓ = Measure(Γ,2*order)
+      n = get_normal_vector(Γ)
+      sum(∫(j ∘ (n-n_g))dΓ)
+    end
+    dJ_FD = FiniteDiff.finite_difference_gradient(J_fdm_surf,get_free_dof_values(φh))
+    d²J_FD = compute_hess ? FiniteDiff.finite_difference_hessian(J_fdm_surf,get_free_dof_values(φh)) : nothing
+
+    abs_error_fdm = norm(dJ_int_AD_vec - dJ_FD,Inf)
+    abs_error_fdm_hess = compute_hess ? norm(d²J - d²J_FD,Inf) : nothing
+
+    if verbose
+      println("D) g(n) surf integral:")
+      println("  - norm(dJ_AD - dJ_exact,Inf) = ","N/A")
+      println("  - norm(dJ_AD - dJ_FDM,Inf) = ",abs_error_fdm)
+      compute_hess && println("  - norm(d²J_AD - d²J_FDM,Inf) = ",abs_error_fdm_hess)
+    end
+  end
+end
+
+#######################
+
+# FDM is quite expensive, so we only run if required.
+
+D = 2
+n = 10
+model = generate_model(D,n)
+f(x) = x[1]+x[2]
+fvec((x,y)) = VectorValue((1-x)^2,(1-y)^2)
+main(model,level_set(:circle_2),f;vtk=false,verbose=true,name="2D_circle/")#,fdm=true)
+main(model,level_set(:regular_2d),f;vtk=false,verbose=true,name="2D_reg/")#,fdm=true)
+main_normal(model,level_set(:circle_2),fvec;vtk=false,verbose=true,name="2D_circle_flux/",run_test=true)#,fdm=true)
+main_normal(model,level_set(:regular_2d),fvec;vtk=false,verbose=true,name="2D_reg_flux/",run_test=false)#,fdm=true) # This will fail as expected
+main_fdm_only_verif(model,level_set(:circle_2),verbose=true)#,fdm=true)
+main_fdm_only_verif(model,level_set(:regular_2d),verbose=true,compute_hess=true)#,fdm=true)
+
+D = 3
+n = 4
+model = generate_model(D,n)
+φ = level_set(:regular_3d)
+f(x) = x[1]+x[2]
+fvec2((x,y,z)) = VectorValue((1-x)^2,(1-y)^2,0)
+main(model,level_set(:sphere_2),f;vtk=false,verbose=true,name="3D_circle/")#,fdm=true)
+main(model,level_set(:regular_3d),f;vtk=false,verbose=true,name="3D_reg/")#,fdm=true)
+main_normal(model,level_set(:sphere_2),fvec2;vtk=false,verbose=true,name="3D_circle_flux/",run_test=true)#,fdm=true)
+main_normal(model,level_set(:regular_3d),fvec2;vtk=false,verbose=true,name="3D_reg_flux/",run_test=false,)#fdm=true) # This will fail as expected
+main_fdm_only_verif(model,level_set(:sphere_2),verbose=true)#,fdm=true)
+main_fdm_only_verif(model,level_set(:regular_3d),verbose=true)#,fdm=true)
+
+end

--- a/test/LevelSetCuttersTests/GeometricalDifferentiationTests.jl
+++ b/test/LevelSetCuttersTests/GeometricalDifferentiationTests.jl
@@ -4,7 +4,7 @@ module GeometricalDifferentiationTests
 # level set defining the cut domain. 
 # They are based on the following work:
 # "Level-set topology optimisation with unfitted finite elements and automatic shape differentiation"
-#   by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis, CMAME (2025)
+#   by Z. J. Wegert, J. Manyer, C. Mallon, S. Badia, V. J. Challis (2025)
 ############################################################################################
 using Test, FiniteDiff
 
@@ -16,23 +16,6 @@ using GridapEmbedded.Interfaces: get_subfacet_normal_vector
 using GridapEmbedded.Interfaces: get_ghost_normal_vector
 
 using GridapEmbedded.LevelSetCutters: DifferentiableTriangulation
-
-
-using Gridap.Fields, Gridap.Polynomials
-function Arrays.return_cache(
-  fg::Fields.FieldGradientArray{1,Polynomials.MonomialBasis{D,V}},
-  x::AbstractVector{<:Point}) where {D,V}
-  xi = testitem(x)
-  T = gradient_type(V,xi)
-  Polynomials._return_cache(fg,x,T,Val(false))
-end
-
-function Arrays.evaluate!(
-  cache,
-  fg::Fields.FieldGradientArray{1,Polynomials.MonomialBasis{D,V}},
-  x::AbstractVector{<:Point}) where {D,V}
-  Polynomials._evaluate!(cache,fg,x,Val(false))
-end
 
 # We general a simplicial model where the simplices are created in a symmetric way using 
 # varycentric refinement of QUADs and HEXs.

--- a/test/LevelSetCuttersTests/runtests.jl
+++ b/test/LevelSetCuttersTests/runtests.jl
@@ -12,4 +12,6 @@ using Test
 
 @testset "LevelSetCutters" begin include("LevelSetCuttersTests.jl") end
 
+@testset "GeometricalDifferentiation" begin include("GeometricalDifferentiationTests.jl") end
+
 end # module


### PR DESCRIPTION
This PR brings code from GridapTopOpt. 

Given a mesh cut by a finite-element-defined level set `φh`, and a functional `j(uh,φh)`, the changes allow the user to compute the gradient of `j` w.r.t. the geometry, i.e `∂ j(uh,φh) / ∂ φh`.

We provide two methods, which are equivalent up to machine error: 

- A discretise then differentiate framework
- A fully-autodiff framework

While I was doing this, I also added a fully-fledged documentation.
