### PR TITLE
Add support for complex-valued dofs

### DIFF
--- a/src/LevelSetCutters/DifferentiableTriangulations.jl
+++ b/src/LevelSetCutters/DifferentiableTriangulations.jl
@@ -432,7 +432,9 @@ function extract_dualized_cell_values(
   bgcell_to_rcoords = lazy_map(get_vertex_coordinates,bgcell_to_polys)
   bgcell_to_fields = CellData.get_data(φh)
   bgcell_to_values = lazy_map(evaluate,bgcell_to_fields,bgcell_to_rcoords)
-  return bgcell_to_values
+  # When φh has complex-valued DOFs, we define the geometry using the real part.
+  bgcell_to_rvalues = lazy_map(real,bgcell_to_values)
+  return bgcell_to_rvalues
 end
 
 # TriangulationView

--- a/src/LevelSetCutters/DiscreteGeometries.jl
+++ b/src/LevelSetCutters/DiscreteGeometries.jl
@@ -85,14 +85,15 @@ function DiscreteGeometry(
   DiscreteGeometry(tree,point_to_coords)
 end
 
-# TODO: This assumes that the level set φh is 1st order, i.e that there is a 1-to-1 correspondence
+# NOTE 1: This assumes that the level set φh is 1st order, i.e that there is a 1-to-1 correspondence
 # between nodes in the mesh and dofs in φh. 
 # Even if we allowed higher order, the cuts are always linear. Not only it would be a waste
 # of time to use higher order, but cuts could actually be wrong.
 # This might be developped in the future.
+# NOTE 2: When φh has complex-valued DOFs, we define the geometry using the real part of the dofs.
 function DiscreteGeometry(
   φh::CellField,model::DiscreteModel;name::String="")
-  point_to_value = get_free_dof_values(φh)
+  point_to_value = real(get_free_dof_values(φh))
   point_to_coords = collect1d(get_node_coordinates(model))
   DiscreteGeometry(point_to_value,point_to_coords;name)
 end


### PR DESCRIPTION
When using AD for complex-valued problems (i.e., [Gridap#1325](https://github.com/gridap/Gridap.jl/pull/1325)), the FESpace of the perturbed quantity must have `vector_type<:AbstractVector{<:Complex}`. For these cases, to use the `DifferentiableTriangulation` machinery, we need the `DiscreteGeometry` to take an `FEFunction` with complex-valued DOFs.  

To handle this case, this PR proposes to define geometries using the real part of the provided `FEFunction`.